### PR TITLE
chore: update module specifiers for recent versions of node

### DIFF
--- a/packages/spelunker-api/src/index.mjs
+++ b/packages/spelunker-api/src/index.mjs
@@ -1,5 +1,5 @@
-import server from './lib/server';
-import { log } from './lib/utils/logger';
+import server from './lib/server.mjs';
+import { log } from './lib/utils/logger.mjs';
 
 server.listen(process.env.API_PORT, () => {
   log(`listening on port ${process.env.API_PORT}`);

--- a/packages/spelunker-api/src/lib/core/Entity.mjs
+++ b/packages/spelunker-api/src/lib/core/Entity.mjs
@@ -1,6 +1,6 @@
-import { notImplemented } from '../utils/abstract';
+import { notImplemented } from '../utils/abstract.mjs';
 
-import NoneQuery from './NoneQuery';
+import NoneQuery from './NoneQuery.mjs';
 
 class Entity {
   constructor(data) {

--- a/packages/spelunker-api/src/lib/core/NoneQuery.mjs
+++ b/packages/spelunker-api/src/lib/core/NoneQuery.mjs
@@ -1,4 +1,4 @@
-import Query from './Query';
+import Query from './Query.mjs';
 
 class NoneQuery extends Query {
   execute() {

--- a/packages/spelunker-api/src/lib/core/Query.mjs
+++ b/packages/spelunker-api/src/lib/core/Query.mjs
@@ -1,4 +1,4 @@
-import { notImplemented } from '../utils/abstract';
+import { notImplemented } from '../utils/abstract.mjs';
 
 class Query {
   constructor(entity) {

--- a/packages/spelunker-api/src/lib/core/memory/Entity.mjs
+++ b/packages/spelunker-api/src/lib/core/memory/Entity.mjs
@@ -1,8 +1,8 @@
-import Entity from '../Entity';
-import cache from '../../utils/cache';
-import { notImplemented } from '../../utils/abstract';
+import Entity from '../Entity.mjs';
+import cache from '../../utils/cache.mjs';
+import { notImplemented } from '../../utils/abstract.mjs';
 
-import MemoryQuery from './Query';
+import MemoryQuery from './Query.mjs';
 
 class MemoryEntity extends Entity {
   static get data() {

--- a/packages/spelunker-api/src/lib/core/memory/Query.mjs
+++ b/packages/spelunker-api/src/lib/core/memory/Query.mjs
@@ -1,5 +1,5 @@
-import Query from '../Query';
-import { notImplemented } from '../../utils/abstract';
+import Query from '../Query.mjs';
+import { notImplemented } from '../../utils/abstract.mjs';
 
 class MemoryQuery extends Query {
   constructor(entity, { label } = {}) {

--- a/packages/spelunker-api/src/lib/db/Entity.mjs
+++ b/packages/spelunker-api/src/lib/db/Entity.mjs
@@ -1,7 +1,7 @@
-import Entity from '../core/Entity';
-import { notImplemented } from '../utils/abstract';
+import Entity from '../core/Entity.mjs';
+import { notImplemented } from '../utils/abstract.mjs';
 
-import DatabaseQuery from './Query';
+import DatabaseQuery from './Query.mjs';
 
 class DatabaseEntity extends Entity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/db/FixedColumnQuery.mjs
+++ b/packages/spelunker-api/src/lib/db/FixedColumnQuery.mjs
@@ -1,5 +1,5 @@
-import MemoryQuery from '../core/memory/Query';
-import logger from '../utils/logger';
+import MemoryQuery from '../core/memory/Query.mjs';
+import logger from '../utils/logger.mjs';
 
 const log = logger('db:fcq');
 

--- a/packages/spelunker-api/src/lib/db/Query.mjs
+++ b/packages/spelunker-api/src/lib/db/Query.mjs
@@ -1,7 +1,7 @@
-import knexQueryMethods from 'knex/lib/query/methods';
+import knexQueryMethods from 'knex/lib/query/methods.js';
 
-import Query from '../core/Query';
-import logger from '../utils/logger';
+import Query from '../core/Query.mjs';
+import logger from '../utils/logger.mjs';
 
 const log = logger('db');
 

--- a/packages/spelunker-api/src/lib/dbc/Entity.mjs
+++ b/packages/spelunker-api/src/lib/dbc/Entity.mjs
@@ -1,7 +1,7 @@
-import MemoryEntity from '../core/memory/Entity';
-import { notImplemented } from '../utils/abstract';
+import MemoryEntity from '../core/memory/Entity.mjs';
+import { notImplemented } from '../utils/abstract.mjs';
 
-import DBCQuery from './Query';
+import DBCQuery from './Query.mjs';
 
 class DBCEntity extends MemoryEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/dbc/Query.mjs
+++ b/packages/spelunker-api/src/lib/dbc/Query.mjs
@@ -1,10 +1,10 @@
-import DBC from 'blizzardry/lib/dbc/entities';
-import restructure from 'blizzardry/lib/restructure';
+import DBC from 'blizzardry/lib/dbc/entities/index.js';
+import restructure from 'blizzardry/lib/restructure.js';
 
-import MemoryQuery from '../core/memory/Query';
-import cache from '../utils/cache';
-import logger from '../utils/logger';
-import mpq from '../mpq';
+import MemoryQuery from '../core/memory/Query.mjs';
+import cache from '../utils/cache.mjs';
+import logger from '../utils/logger.mjs';
+import mpq from '../mpq/index.mjs';
 
 const { DecodeStream } = restructure;
 

--- a/packages/spelunker-api/src/lib/entities/Account.mjs
+++ b/packages/spelunker-api/src/lib/entities/Account.mjs
@@ -1,7 +1,7 @@
-import DatabaseEntity from '../db/Entity';
-import { authConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { authConnection } from '../db/connections.mjs';
 
-import Character from './Character';
+import Character from './Character.mjs';
 
 class Account extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/Area.mjs
+++ b/packages/spelunker-api/src/lib/entities/Area.mjs
@@ -1,10 +1,10 @@
-import DBCEntity from '../dbc/Entity';
-import { contains } from '../utils/string';
+import DBCEntity from '../dbc/Entity.mjs';
+import { contains } from '../utils/string.mjs';
 
-import Map from './Map';
-import Quest from './Quest';
-import Side from './Side';
-import WorldMapArea from './WorldMapArea';
+import Map from './Map.mjs';
+import Quest from './Quest.mjs';
+import Side from './Side.mjs';
+import WorldMapArea from './WorldMapArea.mjs';
 
 class Area extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/CharBaseInfo.mjs
+++ b/packages/spelunker-api/src/lib/entities/CharBaseInfo.mjs
@@ -1,7 +1,7 @@
-import DBCEntity from '../dbc/Entity';
+import DBCEntity from '../dbc/Entity.mjs';
 
-import Class from './Class';
-import Race from './Race';
+import Class from './Class.mjs';
+import Race from './Race.mjs';
 
 class CharBaseInfo extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/Character.mjs
+++ b/packages/spelunker-api/src/lib/entities/Character.mjs
@@ -1,16 +1,16 @@
-import DatabaseEntity from '../db/Entity';
-import { charactersConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { charactersConnection } from '../db/connections.mjs';
 
-import Account from './Account';
-import CharacterItem from './CharacterItem';
-import CharacterQuestStatus from './CharacterQuestStatus';
-import CharacterQuestStatusRewarded from './CharacterQuestStatusRewarded';
-import CharacterReputation from './CharacterReputation';
-import CharacterSpawn from './CharacterSpawn';
-import Class from './Class';
-import Location from './Location';
-import Race from './Race';
-import Quest from './Quest';
+import Account from './Account.mjs';
+import CharacterItem from './CharacterItem.mjs';
+import CharacterQuestStatus from './CharacterQuestStatus.mjs';
+import CharacterQuestStatusRewarded from './CharacterQuestStatusRewarded.mjs';
+import CharacterReputation from './CharacterReputation.mjs';
+import CharacterSpawn from './CharacterSpawn.mjs';
+import Class from './Class.mjs';
+import Location from './Location.mjs';
+import Race from './Race.mjs';
+import Quest from './Quest.mjs';
 
 class Character extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/CharacterItem.mjs
+++ b/packages/spelunker-api/src/lib/entities/CharacterItem.mjs
@@ -1,8 +1,8 @@
-import DatabaseEntity from '../db/Entity';
-import { charactersConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { charactersConnection } from '../db/connections.mjs';
 
-import Character from './Character';
-import Item from './Item';
+import Character from './Character.mjs';
+import Item from './Item.mjs';
 
 class CharacterItem extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/CharacterQuestStatus.mjs
+++ b/packages/spelunker-api/src/lib/entities/CharacterQuestStatus.mjs
@@ -1,8 +1,8 @@
-import DatabaseEntity from '../db/Entity';
-import { charactersConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { charactersConnection } from '../db/connections.mjs';
 
-import Character from './Character';
-import Quest from './Quest';
+import Character from './Character.mjs';
+import Quest from './Quest.mjs';
 
 class CharacterQuestStatus extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/CharacterQuestStatusRewarded.mjs
+++ b/packages/spelunker-api/src/lib/entities/CharacterQuestStatusRewarded.mjs
@@ -1,5 +1,5 @@
-import DatabaseEntity from '../db/Entity';
-import { charactersConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { charactersConnection } from '../db/connections.mjs';
 
 class CharacterQuestStatusRewarded extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/CharacterReputation.mjs
+++ b/packages/spelunker-api/src/lib/entities/CharacterReputation.mjs
@@ -1,8 +1,8 @@
-import DatabaseEntity from '../db/Entity';
-import { charactersConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { charactersConnection } from '../db/connections.mjs';
 
-import Character from './Character';
-import Faction from './Faction';
+import Character from './Character.mjs';
+import Faction from './Faction.mjs';
 
 class CharacterReputation extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/CharacterSpawn.mjs
+++ b/packages/spelunker-api/src/lib/entities/CharacterSpawn.mjs
@@ -1,5 +1,5 @@
-import Area from './Area';
-import Map from './Map';
+import Area from './Area.mjs';
+import Map from './Map.mjs';
 
 class CharacterSpawn {
   constructor(data) {

--- a/packages/spelunker-api/src/lib/entities/Class.mjs
+++ b/packages/spelunker-api/src/lib/entities/Class.mjs
@@ -1,11 +1,11 @@
-import DBCEntity from '../dbc/Entity';
-import cache from '../utils/cache';
-import glueStrings from '../mpq/files/GlueStrings';
-import { contains } from '../utils/string';
+import DBCEntity from '../dbc/Entity.mjs';
+import cache from '../utils/cache.mjs';
+import glueStrings from '../mpq/files/GlueStrings.mjs';
+import { contains } from '../utils/string.mjs';
 
-import CharBaseInfo from './CharBaseInfo';
-import Race from './Race';
-import Quest from './Quest';
+import CharBaseInfo from './CharBaseInfo.mjs';
+import Race from './Race.mjs';
+import Quest from './Quest.mjs';
 
 class Class extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/Faction.mjs
+++ b/packages/spelunker-api/src/lib/entities/Faction.mjs
@@ -1,7 +1,7 @@
-import DBCEntity from '../dbc/Entity';
-import { contains } from '../utils/string';
+import DBCEntity from '../dbc/Entity.mjs';
+import { contains } from '../utils/string.mjs';
 
-import Quest from './Quest';
+import Quest from './Quest.mjs';
 
 class Faction extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/GameObject.mjs
+++ b/packages/spelunker-api/src/lib/entities/GameObject.mjs
@@ -1,12 +1,12 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import GameObjectLoot from './GameObjectLoot';
-import GameObjectQuestFinisher from './GameObjectQuestFinisher';
-import GameObjectQuestStarter from './GameObjectQuestStarter';
-import GameObjectSpawn from './GameObjectSpawn';
-import Location from './Location';
-import Quest from './Quest';
+import GameObjectLoot from './GameObjectLoot.mjs';
+import GameObjectQuestFinisher from './GameObjectQuestFinisher.mjs';
+import GameObjectQuestStarter from './GameObjectQuestStarter.mjs';
+import GameObjectSpawn from './GameObjectSpawn.mjs';
+import Location from './Location.mjs';
+import Quest from './Quest.mjs';
 
 class GameObject extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/GameObjectLoot.mjs
+++ b/packages/spelunker-api/src/lib/entities/GameObjectLoot.mjs
@@ -1,8 +1,8 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import GameObject from './GameObject';
-import Item from './Item';
+import GameObject from './GameObject.mjs';
+import Item from './Item.mjs';
 
 class GameObjectLoot extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/GameObjectQuestFinisher.mjs
+++ b/packages/spelunker-api/src/lib/entities/GameObjectQuestFinisher.mjs
@@ -1,5 +1,5 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
 class GameObjectQuestFinisher extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/GameObjectQuestStarter.mjs
+++ b/packages/spelunker-api/src/lib/entities/GameObjectQuestStarter.mjs
@@ -1,5 +1,5 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
 class GameObjectQuestStarter extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/GameObjectSpawn.mjs
+++ b/packages/spelunker-api/src/lib/entities/GameObjectSpawn.mjs
@@ -1,9 +1,9 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import Area from './Area';
-import GameObject from './GameObject';
-import Map from './Map';
+import Area from './Area.mjs';
+import GameObject from './GameObject.mjs';
+import Map from './Map.mjs';
 
 class GameObjectSpawn extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/Item.mjs
+++ b/packages/spelunker-api/src/lib/entities/Item.mjs
@@ -1,13 +1,13 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import GameObjectLoot from './GameObjectLoot';
-import ItemDisplayInfo from './ItemDisplayInfo';
-import ItemLoot from './ItemLoot';
-import ItemSet from './ItemSet';
-import NPCLoot from './NPCLoot';
-import NPCSale from './NPCSale';
-import Quest from './Quest';
+import GameObjectLoot from './GameObjectLoot.mjs';
+import ItemDisplayInfo from './ItemDisplayInfo.mjs';
+import ItemLoot from './ItemLoot.mjs';
+import ItemSet from './ItemSet.mjs';
+import NPCLoot from './NPCLoot.mjs';
+import NPCSale from './NPCSale.mjs';
+import Quest from './Quest.mjs';
 
 class Item extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/ItemDisplayInfo.mjs
+++ b/packages/spelunker-api/src/lib/entities/ItemDisplayInfo.mjs
@@ -1,4 +1,4 @@
-import DBCEntity from '../dbc/Entity';
+import DBCEntity from '../dbc/Entity.mjs';
 
 class ItemDisplayInfo extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/ItemLoot.mjs
+++ b/packages/spelunker-api/src/lib/entities/ItemLoot.mjs
@@ -1,7 +1,7 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import Item from './Item';
+import Item from './Item.mjs';
 
 class ItemLoot extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/ItemSet.mjs
+++ b/packages/spelunker-api/src/lib/entities/ItemSet.mjs
@@ -1,7 +1,7 @@
-import DBCEntity from '../dbc/Entity';
-import { contains } from '../utils/string';
+import DBCEntity from '../dbc/Entity.mjs';
+import { contains } from '../utils/string.mjs';
 
-import Item from './Item';
+import Item from './Item.mjs';
 
 class ItemSet extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/Location.mjs
+++ b/packages/spelunker-api/src/lib/entities/Location.mjs
@@ -1,4 +1,4 @@
-import MemoryQuery from '../core/memory/Query';
+import MemoryQuery from '../core/memory/Query.mjs';
 
 class Location {
   constructor(map) {

--- a/packages/spelunker-api/src/lib/entities/Map.mjs
+++ b/packages/spelunker-api/src/lib/entities/Map.mjs
@@ -1,14 +1,14 @@
-import WDT from 'blizzardry/lib/wdt';
-import restructure from 'blizzardry/lib/restructure';
+import WDT from 'blizzardry/lib/wdt/index.js';
+import restructure from 'blizzardry/lib/restructure.js';
 
-import DBCEntity from '../dbc/Entity';
-import cache from '../utils/cache';
-import mpq from '../mpq';
-import { contains } from '../utils/string';
+import DBCEntity from '../dbc/Entity.mjs';
+import cache from '../utils/cache.mjs';
+import mpq from '../mpq/index.mjs';
+import { contains } from '../utils/string.mjs';
 
-import Area from './Area';
-import GameObjectSpawn from './GameObjectSpawn';
-import NPCSpawn from './NPCSpawn';
+import Area from './Area.mjs';
+import GameObjectSpawn from './GameObjectSpawn.mjs';
+import NPCSpawn from './NPCSpawn.mjs';
 
 const { DecodeStream } = restructure;
 

--- a/packages/spelunker-api/src/lib/entities/NPC.mjs
+++ b/packages/spelunker-api/src/lib/entities/NPC.mjs
@@ -1,14 +1,14 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import Location from './Location';
-import NPCLoot from './NPCLoot';
-import NPCQuestFinisher from './NPCQuestFinisher';
-import NPCQuestStarter from './NPCQuestStarter';
-import NPCSale from './NPCSale';
-import NPCSpawn from './NPCSpawn';
-import NPCTraining from './NPCTraining';
-import Quest from './Quest';
+import Location from './Location.mjs';
+import NPCLoot from './NPCLoot.mjs';
+import NPCQuestFinisher from './NPCQuestFinisher.mjs';
+import NPCQuestStarter from './NPCQuestStarter.mjs';
+import NPCSale from './NPCSale.mjs';
+import NPCSpawn from './NPCSpawn.mjs';
+import NPCTraining from './NPCTraining.mjs';
+import Quest from './Quest.mjs';
 
 class NPC extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/NPCLoot.mjs
+++ b/packages/spelunker-api/src/lib/entities/NPCLoot.mjs
@@ -1,8 +1,8 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import Item from './Item';
-import NPC from './NPC';
+import Item from './Item.mjs';
+import NPC from './NPC.mjs';
 
 class NPCLoot extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/NPCQuestFinisher.mjs
+++ b/packages/spelunker-api/src/lib/entities/NPCQuestFinisher.mjs
@@ -1,5 +1,5 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
 class NPCQuestFinisher extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/NPCQuestStarter.mjs
+++ b/packages/spelunker-api/src/lib/entities/NPCQuestStarter.mjs
@@ -1,5 +1,5 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
 class NPCQuestStarter extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/NPCSale.mjs
+++ b/packages/spelunker-api/src/lib/entities/NPCSale.mjs
@@ -1,8 +1,8 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import Item from './Item';
-import NPC from './NPC';
+import Item from './Item.mjs';
+import NPC from './NPC.mjs';
 
 class NPCSale extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/NPCSpawn.mjs
+++ b/packages/spelunker-api/src/lib/entities/NPCSpawn.mjs
@@ -1,9 +1,9 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import Area from './Area';
-import Map from './Map';
-import NPC from './NPC';
+import Area from './Area.mjs';
+import Map from './Map.mjs';
+import NPC from './NPC.mjs';
 
 class NPCSpawn extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/NPCTraining.mjs
+++ b/packages/spelunker-api/src/lib/entities/NPCTraining.mjs
@@ -1,8 +1,8 @@
-import DatabaseEntity from '../db/Entity';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import NPC from './NPC';
-import Spell from './Spell';
+import NPC from './NPC.mjs';
+import Spell from './Spell.mjs';
 
 class NPCTraining extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/Quest.mjs
+++ b/packages/spelunker-api/src/lib/entities/Quest.mjs
@@ -1,21 +1,21 @@
-import DatabaseEntity from '../db/Entity';
-import FixedColumnQuery from '../db/FixedColumnQuery';
-import MemoryQuery from '../core/memory/Query';
-import { worldConnection } from '../db/connections';
+import DatabaseEntity from '../db/Entity.mjs';
+import FixedColumnQuery from '../db/FixedColumnQuery.mjs';
+import MemoryQuery from '../core/memory/Query.mjs';
+import { worldConnection } from '../db/connections.mjs';
 
-import Class from './Class';
-import Faction from './Faction';
-import GameObject from './GameObject';
-import GameObjectQuestFinisher from './GameObjectQuestFinisher';
-import GameObjectQuestStarter from './GameObjectQuestStarter';
-import Item from './Item';
-import NPC from './NPC';
-import NPCQuestFinisher from './NPCQuestFinisher';
-import NPCQuestStarter from './NPCQuestStarter';
-import QuestCategory from './QuestCategory';
-import Race from './Race';
-import Side from './Side';
-import Spell from './Spell';
+import Class from './Class.mjs';
+import Faction from './Faction.mjs';
+import GameObject from './GameObject.mjs';
+import GameObjectQuestFinisher from './GameObjectQuestFinisher.mjs';
+import GameObjectQuestStarter from './GameObjectQuestStarter.mjs';
+import Item from './Item.mjs';
+import NPC from './NPC.mjs';
+import NPCQuestFinisher from './NPCQuestFinisher.mjs';
+import NPCQuestStarter from './NPCQuestStarter.mjs';
+import QuestCategory from './QuestCategory.mjs';
+import Race from './Race.mjs';
+import Side from './Side.mjs';
+import Spell from './Spell.mjs';
 
 class Quest extends DatabaseEntity {
   static get connection() {

--- a/packages/spelunker-api/src/lib/entities/QuestCategory.mjs
+++ b/packages/spelunker-api/src/lib/entities/QuestCategory.mjs
@@ -1,5 +1,5 @@
-import Area from './Area';
-import QuestSort from './QuestSort';
+import Area from './Area.mjs';
+import QuestSort from './QuestSort.mjs';
 
 class QuestCategory {
   static find(id) {

--- a/packages/spelunker-api/src/lib/entities/QuestSort.mjs
+++ b/packages/spelunker-api/src/lib/entities/QuestSort.mjs
@@ -1,4 +1,4 @@
-import DBCEntity from '../dbc/Entity';
+import DBCEntity from '../dbc/Entity.mjs';
 
 class QuestSort extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/Race.mjs
+++ b/packages/spelunker-api/src/lib/entities/Race.mjs
@@ -1,11 +1,11 @@
-import DBCEntity from '../dbc/Entity';
-import glueStrings from '../mpq/files/GlueStrings';
-import { contains } from '../utils/string';
+import DBCEntity from '../dbc/Entity.mjs';
+import glueStrings from '../mpq/files/GlueStrings.mjs';
+import { contains } from '../utils/string.mjs';
 
-import CharBaseInfo from './CharBaseInfo';
-import Class from './Class';
-import Quest from './Quest';
-import Side from './Side';
+import CharBaseInfo from './CharBaseInfo.mjs';
+import Class from './Class.mjs';
+import Quest from './Quest.mjs';
+import Side from './Side.mjs';
 
 class Race extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/Side.mjs
+++ b/packages/spelunker-api/src/lib/entities/Side.mjs
@@ -1,10 +1,10 @@
-import MemoryEntity from '../core/memory/Entity';
-import glueStrings from '../mpq/files/GlueStrings';
-import { contains } from '../utils/string';
+import MemoryEntity from '../core/memory/Entity.mjs';
+import glueStrings from '../mpq/files/GlueStrings.mjs';
+import { contains } from '../utils/string.mjs';
 
-import Area from './Area';
-import Quest from './Quest';
-import Race from './Race';
+import Area from './Area.mjs';
+import Quest from './Quest.mjs';
+import Race from './Race.mjs';
 
 class Side extends MemoryEntity {
   static get data() {

--- a/packages/spelunker-api/src/lib/entities/Spell.mjs
+++ b/packages/spelunker-api/src/lib/entities/Spell.mjs
@@ -1,9 +1,9 @@
-import DBCEntity from '../dbc/Entity';
-import { contains } from '../utils/string';
+import DBCEntity from '../dbc/Entity.mjs';
+import { contains } from '../utils/string.mjs';
 
-import NPCTraining from './NPCTraining';
-import Quest from './Quest';
-import SpellIcon from './SpellIcon';
+import NPCTraining from './NPCTraining.mjs';
+import Quest from './Quest.mjs';
+import SpellIcon from './SpellIcon.mjs';
 
 class Spell extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/SpellIcon.mjs
+++ b/packages/spelunker-api/src/lib/entities/SpellIcon.mjs
@@ -1,4 +1,4 @@
-import DBCEntity from '../dbc/Entity';
+import DBCEntity from '../dbc/Entity.mjs';
 
 class SpellIcon extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/entities/WorldMapArea.mjs
+++ b/packages/spelunker-api/src/lib/entities/WorldMapArea.mjs
@@ -1,6 +1,6 @@
-import DBCEntity from '../dbc/Entity';
+import DBCEntity from '../dbc/Entity.mjs';
 
-import Area from './Area';
+import Area from './Area.mjs';
 
 class WorldMapArea extends DBCEntity {
   static get dbc() {

--- a/packages/spelunker-api/src/lib/graph/root.mjs
+++ b/packages/spelunker-api/src/lib/graph/root.mjs
@@ -1,17 +1,17 @@
-import Account from '../entities/Account';
-import Area from '../entities/Area';
-import Character from '../entities/Character';
-import Class from '../entities/Class';
-import Faction from '../entities/Faction';
-import GameObject from '../entities/GameObject';
-import Item from '../entities/Item';
-import ItemSet from '../entities/ItemSet';
-import Map from '../entities/Map';
-import NPC from '../entities/NPC';
-import Quest from '../entities/Quest';
-import Race from '../entities/Race';
-import Side from '../entities/Side';
-import Spell from '../entities/Spell';
+import Account from '../entities/Account.mjs';
+import Area from '../entities/Area.mjs';
+import Character from '../entities/Character.mjs';
+import Class from '../entities/Class.mjs';
+import Faction from '../entities/Faction.mjs';
+import GameObject from '../entities/GameObject.mjs';
+import Item from '../entities/Item.mjs';
+import ItemSet from '../entities/ItemSet.mjs';
+import Map from '../entities/Map.mjs';
+import NPC from '../entities/NPC.mjs';
+import Quest from '../entities/Quest.mjs';
+import Race from '../entities/Race.mjs';
+import Side from '../entities/Side.mjs';
+import Spell from '../entities/Spell.mjs';
 
 export default {
   accounts: ({ searchQuery }) => Account.query.search(searchQuery),

--- a/packages/spelunker-api/src/lib/graph/schema/BoundsType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/BoundsType.mjs
@@ -2,7 +2,7 @@ import {
   GraphQLFloat,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../graphql';
+} from '../../graphql/index.mjs';
 
 export default new GraphQLObjectType({
   name: 'Bounds',

--- a/packages/spelunker-api/src/lib/graph/schema/CollectionType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/CollectionType.mjs
@@ -3,10 +3,10 @@ import {
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../graphql';
-import { cache } from '../../graphql/utils';
+} from '../../graphql/index.mjs';
+import { cache } from '../../graphql/utils.mjs';
 
-import Collection from '../../core/Collection';
+import Collection from '../../core/Collection.mjs';
 
 class CollectionType extends GraphQLObjectType {
   static for(wrappedType) {

--- a/packages/spelunker-api/src/lib/graph/schema/CurrencyType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/CurrencyType.mjs
@@ -1,3 +1,3 @@
 export {
   GraphQLInt as default,
-} from '../../graphql';
+} from '../../graphql/index.mjs';

--- a/packages/spelunker-api/src/lib/graph/schema/QueryType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/QueryType.mjs
@@ -3,24 +3,24 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../graphql';
+} from '../../graphql/index.mjs';
 
-import CollectionType from './CollectionType';
+import CollectionType from './CollectionType.mjs';
 
-import AccountType from './entities/AccountType';
-import AreaType from './entities/AreaType';
-import CharacterType from './entities/CharacterType';
-import ClassType from './entities/ClassType';
-import FactionType from './entities/FactionType';
-import GameObjectType from './entities/GameObjectType';
-import ItemType from './entities/ItemType';
-import ItemSetType from './entities/ItemSetType';
-import MapType from './entities/MapType';
-import NPCType from './entities/NPCType';
-import QuestType from './entities/QuestType';
-import RaceType from './entities/RaceType';
-import SideType from './entities/SideType';
-import SpellType from './entities/SpellType';
+import AccountType from './entities/AccountType.mjs';
+import AreaType from './entities/AreaType.mjs';
+import CharacterType from './entities/CharacterType.mjs';
+import ClassType from './entities/ClassType.mjs';
+import FactionType from './entities/FactionType.mjs';
+import GameObjectType from './entities/GameObjectType.mjs';
+import ItemType from './entities/ItemType.mjs';
+import ItemSetType from './entities/ItemSetType.mjs';
+import MapType from './entities/MapType.mjs';
+import NPCType from './entities/NPCType.mjs';
+import QuestType from './entities/QuestType.mjs';
+import RaceType from './entities/RaceType.mjs';
+import SideType from './entities/SideType.mjs';
+import SpellType from './entities/SpellType.mjs';
 
 const finderFor = (type, idType = GraphQLInt) => ({
   type,

--- a/packages/spelunker-api/src/lib/graph/schema/entities/AccountType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/AccountType.mjs
@@ -3,11 +3,11 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import CharacterType from './CharacterType';
+import CharacterType from './CharacterType.mjs';
 
 export default new GraphQLObjectType({
   name: 'Account',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/AreaType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/AreaType.mjs
@@ -3,14 +3,14 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import BoundsType from '../BoundsType';
-import CollectionType from '../CollectionType';
+import BoundsType from '../BoundsType.mjs';
+import CollectionType from '../CollectionType.mjs';
 
-import MapType from './MapType';
-import QuestType from './QuestType';
-import SideType from './SideType';
+import MapType from './MapType.mjs';
+import QuestType from './QuestType.mjs';
+import SideType from './SideType.mjs';
 
 const AreaType = new GraphQLObjectType({
   name: 'Area',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/CharacterItemType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/CharacterItemType.mjs
@@ -2,10 +2,10 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CharacterType from './CharacterType';
-import ItemType from './ItemType';
+import CharacterType from './CharacterType.mjs';
+import ItemType from './ItemType.mjs';
 
 export default new GraphQLObjectType({
   name: 'CharacterItem',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/CharacterQuestType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/CharacterQuestType.mjs
@@ -2,10 +2,10 @@ import {
   GraphQLEnumType,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CharacterType from './CharacterType';
-import QuestType from './QuestType';
+import CharacterType from './CharacterType.mjs';
+import QuestType from './QuestType.mjs';
 
 const CharacterQuestStatus = new GraphQLEnumType({
   name: 'CharacterQuestStatus',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/CharacterReputationType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/CharacterReputationType.mjs
@@ -2,10 +2,10 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CharacterType from './CharacterType';
-import FactionType from './FactionType';
+import CharacterType from './CharacterType.mjs';
+import FactionType from './FactionType.mjs';
 
 export default new GraphQLObjectType({
   name: 'CharacterReputation',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/CharacterSpawnType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/CharacterSpawnType.mjs
@@ -2,10 +2,10 @@ import {
   GraphQLFloat,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import AreaType from './AreaType';
-import MapType from './MapType';
+import AreaType from './AreaType.mjs';
+import MapType from './MapType.mjs';
 
 export default new GraphQLObjectType({
   name: 'CharacterSpawn',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/CharacterType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/CharacterType.mjs
@@ -3,20 +3,20 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import AccountType from './AccountType';
-import ClassType from './ClassType';
-import CharacterItemType from './CharacterItemType';
-import CharacterQuestType from './CharacterQuestType';
-import CharacterReputationType from './CharacterReputationType';
-import CharacterSpawnType from './CharacterSpawnType';
-import GenderType from './GenderType';
-import LocationType from './LocationType';
-import QuestType from './QuestType';
-import RaceType from './RaceType';
+import AccountType from './AccountType.mjs';
+import ClassType from './ClassType.mjs';
+import CharacterItemType from './CharacterItemType.mjs';
+import CharacterQuestType from './CharacterQuestType.mjs';
+import CharacterReputationType from './CharacterReputationType.mjs';
+import CharacterSpawnType from './CharacterSpawnType.mjs';
+import GenderType from './GenderType.mjs';
+import LocationType from './LocationType.mjs';
+import QuestType from './QuestType.mjs';
+import RaceType from './RaceType.mjs';
 
 const CharacterType = new GraphQLObjectType({
   name: 'Character',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/ClassType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/ClassType.mjs
@@ -4,12 +4,12 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import QuestType from './QuestType';
-import RaceType from './RaceType';
+import QuestType from './QuestType.mjs';
+import RaceType from './RaceType.mjs';
 
 export default new GraphQLObjectType({
   name: 'Class',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/FactionType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/FactionType.mjs
@@ -3,11 +3,11 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import QuestType from './QuestType';
+import QuestType from './QuestType.mjs';
 
 const FactionType = new GraphQLObjectType({
   name: 'Faction',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/GameObjectLootType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/GameObjectLootType.mjs
@@ -2,10 +2,10 @@ import {
   GraphQLFloat,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import GameObjectType from './GameObjectType';
-import ItemType from './ItemType';
+import GameObjectType from './GameObjectType.mjs';
+import ItemType from './ItemType.mjs';
 
 export default new GraphQLObjectType({
   name: 'GameObjectLoot',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/GameObjectSpawnType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/GameObjectSpawnType.mjs
@@ -3,11 +3,11 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import AreaType from './AreaType';
-import GameObjectType from './GameObjectType';
-import MapType from './MapType';
+import AreaType from './AreaType.mjs';
+import GameObjectType from './GameObjectType.mjs';
+import MapType from './MapType.mjs';
 
 export default new GraphQLObjectType({
   name: 'GameObjectSpawn',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/GameObjectType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/GameObjectType.mjs
@@ -3,15 +3,15 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import GameObjectLootType from './GameObjectLootType';
-import GameObjectSpawnType from './GameObjectSpawnType';
-import GameObjectTypeType from './GameObjectTypeType';
-import { LocationCollectionType } from './LocationType';
-import QuestType from './QuestType';
+import GameObjectLootType from './GameObjectLootType.mjs';
+import GameObjectSpawnType from './GameObjectSpawnType.mjs';
+import GameObjectTypeType from './GameObjectTypeType.mjs';
+import { LocationCollectionType } from './LocationType.mjs';
+import QuestType from './QuestType.mjs';
 
 export default new GraphQLObjectType({
   name: 'GameObject',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/GameObjectTypeType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/GameObjectTypeType.mjs
@@ -1,4 +1,4 @@
-import { generateEnumDefinition } from '../../../graphql/utils';
-import * as types from '../../../entities/GameObjectType';
+import { generateEnumDefinition } from '../../../graphql/utils.mjs';
+import * as types from '../../../entities/GameObjectType.mjs';
 
 export default generateEnumDefinition('GameObjectType', types);

--- a/packages/spelunker-api/src/lib/graph/schema/entities/GenderType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/GenderType.mjs
@@ -1,4 +1,4 @@
-import { generateEnumDefinition } from '../../../graphql/utils';
-import * as types from '../../../entities/Gender';
+import { generateEnumDefinition } from '../../../graphql/utils.mjs';
+import * as types from '../../../entities/Gender.mjs';
 
 export default generateEnumDefinition('Gender', types);

--- a/packages/spelunker-api/src/lib/graph/schema/entities/ItemDisplayInfoType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/ItemDisplayInfoType.mjs
@@ -3,7 +3,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
 export default new GraphQLObjectType({
   name: 'ItemDisplayInfo',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/ItemLootType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/ItemLootType.mjs
@@ -2,9 +2,9 @@ import {
   GraphQLFloat,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import ItemType from './ItemType';
+import ItemType from './ItemType.mjs';
 
 export default new GraphQLObjectType({
   name: 'ItemLoot',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/ItemQualityType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/ItemQualityType.mjs
@@ -1,6 +1,6 @@
 import {
   GraphQLEnumType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
 export default new GraphQLEnumType({
   name: 'ItemQuality',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/ItemSetType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/ItemSetType.mjs
@@ -3,12 +3,12 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import ItemQualityType from './ItemQualityType';
-import ItemType from './ItemType';
+import ItemQualityType from './ItemQualityType.mjs';
+import ItemType from './ItemType.mjs';
 
 export default new GraphQLObjectType({
   name: 'ItemSet',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/ItemType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/ItemType.mjs
@@ -3,19 +3,19 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
-import CurrencyType from '../CurrencyType';
+import CollectionType from '../CollectionType.mjs';
+import CurrencyType from '../CurrencyType.mjs';
 
-import GameObjectLootType from './GameObjectLootType';
-import ItemDisplayInfoType from './ItemDisplayInfoType';
-import ItemLootType from './ItemLootType';
-import ItemQualityType from './ItemQualityType';
-import NPCLootType from './NPCLootType';
-import ItemSetType from './ItemSetType';
-import NPCSaleType from './NPCSaleType';
-import QuestType from './QuestType';
+import GameObjectLootType from './GameObjectLootType.mjs';
+import ItemDisplayInfoType from './ItemDisplayInfoType.mjs';
+import ItemLootType from './ItemLootType.mjs';
+import ItemQualityType from './ItemQualityType.mjs';
+import NPCLootType from './NPCLootType.mjs';
+import ItemSetType from './ItemSetType.mjs';
+import NPCSaleType from './NPCSaleType.mjs';
+import QuestType from './QuestType.mjs';
 
 export default new GraphQLObjectType({
   name: 'Item',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/LocationType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/LocationType.mjs
@@ -2,12 +2,12 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import AreaType from './AreaType';
-import MapType from './MapType';
+import AreaType from './AreaType.mjs';
+import MapType from './MapType.mjs';
 
 const LocationAreaType = new GraphQLObjectType({
   name: 'LocationArea',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/MapType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/MapType.mjs
@@ -3,14 +3,14 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import BoundsType from '../BoundsType';
-import CollectionType from '../CollectionType';
+import BoundsType from '../BoundsType.mjs';
+import CollectionType from '../CollectionType.mjs';
 
-import AreaType from './AreaType';
-import GameObjectSpawnType from './GameObjectSpawnType';
-import NPCSpawnType from './NPCSpawnType';
+import AreaType from './AreaType.mjs';
+import GameObjectSpawnType from './GameObjectSpawnType.mjs';
+import NPCSpawnType from './NPCSpawnType.mjs';
 
 export default new GraphQLObjectType({
   name: 'Map',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/NPCLootType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/NPCLootType.mjs
@@ -2,10 +2,10 @@ import {
   GraphQLFloat,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import ItemType from './ItemType';
-import NPCType from './NPCType';
+import ItemType from './ItemType.mjs';
+import NPCType from './NPCType.mjs';
 
 export default new GraphQLObjectType({
   name: 'NPCLoot',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/NPCSaleType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/NPCSaleType.mjs
@@ -2,10 +2,10 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import ItemType from './ItemType';
-import NPCType from './NPCType';
+import ItemType from './ItemType.mjs';
+import NPCType from './NPCType.mjs';
 
 export default new GraphQLObjectType({
   name: 'NPCSale',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/NPCSpawnType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/NPCSpawnType.mjs
@@ -3,11 +3,11 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import AreaType from './AreaType';
-import MapType from './MapType';
-import NPCType from './NPCType';
+import AreaType from './AreaType.mjs';
+import MapType from './MapType.mjs';
+import NPCType from './NPCType.mjs';
 
 export default new GraphQLObjectType({
   name: 'NPCSpawn',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/NPCTrainingType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/NPCTrainingType.mjs
@@ -1,12 +1,12 @@
 import {
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CurrencyType from '../CurrencyType';
+import CurrencyType from '../CurrencyType.mjs';
 
-import NPCType from './NPCType';
-import SpellType from './SpellType';
+import NPCType from './NPCType.mjs';
+import SpellType from './SpellType.mjs';
 
 export default new GraphQLObjectType({
   name: 'NPCTraining',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/NPCType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/NPCType.mjs
@@ -3,16 +3,16 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import NPCLootType from './NPCLootType';
-import NPCSaleType from './NPCSaleType';
-import NPCSpawnType from './NPCSpawnType';
-import NPCTrainingType from './NPCTrainingType';
-import QuestType from './QuestType';
-import { LocationCollectionType } from './LocationType';
+import NPCLootType from './NPCLootType.mjs';
+import NPCSaleType from './NPCSaleType.mjs';
+import NPCSpawnType from './NPCSpawnType.mjs';
+import NPCTrainingType from './NPCTrainingType.mjs';
+import QuestType from './QuestType.mjs';
+import { LocationCollectionType } from './LocationType.mjs';
 
 export default new GraphQLObjectType({
   name: 'NPC',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/QuestCategoryType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/QuestCategoryType.mjs
@@ -1,9 +1,9 @@
 import {
   GraphQLUnionType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import AreaType from './AreaType';
-import QuestSortType from './QuestSortType';
+import AreaType from './AreaType.mjs';
+import QuestSortType from './QuestSortType.mjs';
 
 const lookup = {
   Area: AreaType,

--- a/packages/spelunker-api/src/lib/graph/schema/entities/QuestFactionType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/QuestFactionType.mjs
@@ -2,9 +2,9 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import FactionType from './FactionType';
+import FactionType from './FactionType.mjs';
 
 export default new GraphQLObjectType({
   name: 'QuestFaction',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/QuestGameObjectType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/QuestGameObjectType.mjs
@@ -2,9 +2,9 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import GameObjectType from './GameObjectType';
+import GameObjectType from './GameObjectType.mjs';
 
 export default new GraphQLObjectType({
   name: 'QuestGameObject',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/QuestItemType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/QuestItemType.mjs
@@ -2,9 +2,9 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import ItemType from './ItemType';
+import ItemType from './ItemType.mjs';
 
 export default new GraphQLObjectType({
   name: 'QuestItem',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/QuestNPCType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/QuestNPCType.mjs
@@ -2,9 +2,9 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import NPCType from './NPCType';
+import NPCType from './NPCType.mjs';
 
 export default new GraphQLObjectType({
   name: 'QuestNPC',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/QuestSortType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/QuestSortType.mjs
@@ -3,7 +3,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
 export default new GraphQLObjectType({
   name: 'QuestSort',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/QuestType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/QuestType.mjs
@@ -5,22 +5,22 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import ClassType from './ClassType';
-import GameObjectType from './GameObjectType';
-import ItemType from './ItemType';
-import NPCType from './NPCType';
-import QuestCategoryType from './QuestCategoryType';
-import QuestFactionType from './QuestFactionType';
-import QuestItemType from './QuestItemType';
-import QuestNPCType from './QuestNPCType';
-import QuestGameObjectType from './QuestGameObjectType';
-import RaceType from './RaceType';
-import SideType from './SideType';
-import SpellType from './SpellType';
+import ClassType from './ClassType.mjs';
+import GameObjectType from './GameObjectType.mjs';
+import ItemType from './ItemType.mjs';
+import NPCType from './NPCType.mjs';
+import QuestCategoryType from './QuestCategoryType.mjs';
+import QuestFactionType from './QuestFactionType.mjs';
+import QuestItemType from './QuestItemType.mjs';
+import QuestNPCType from './QuestNPCType.mjs';
+import QuestGameObjectType from './QuestGameObjectType.mjs';
+import RaceType from './RaceType.mjs';
+import SideType from './SideType.mjs';
+import SpellType from './SpellType.mjs';
 
 const QuestType = new GraphQLObjectType({
   name: 'Quest',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/RaceType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/RaceType.mjs
@@ -4,13 +4,13 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import ClassType from './ClassType';
-import QuestType from './QuestType';
-import SideType from './SideType';
+import ClassType from './ClassType.mjs';
+import QuestType from './QuestType.mjs';
+import SideType from './SideType.mjs';
 
 export default new GraphQLObjectType({
   name: 'Race',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/SideType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/SideType.mjs
@@ -3,13 +3,13 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import AreaType from './AreaType';
-import QuestType from './QuestType';
-import RaceType from './RaceType';
+import AreaType from './AreaType.mjs';
+import QuestType from './QuestType.mjs';
+import RaceType from './RaceType.mjs';
 
 export default new GraphQLObjectType({
   name: 'Side',

--- a/packages/spelunker-api/src/lib/graph/schema/entities/SpellType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/entities/SpellType.mjs
@@ -3,12 +3,12 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-} from '../../../graphql';
+} from '../../../graphql/index.mjs';
 
-import CollectionType from '../CollectionType';
+import CollectionType from '../CollectionType.mjs';
 
-import NPCTrainingType from './NPCTrainingType';
-import QuestType from './QuestType';
+import NPCTrainingType from './NPCTrainingType.mjs';
+import QuestType from './QuestType.mjs';
 
 export default new GraphQLObjectType({
   name: 'Spell',

--- a/packages/spelunker-api/src/lib/graph/schema/index.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/index.mjs
@@ -1,8 +1,8 @@
 import {
   GraphQLSchema,
-} from '../../graphql';
+} from '../../graphql/index.mjs';
 
-import QueryType from './QueryType';
+import QueryType from './QueryType.mjs';
 
 const schema = new GraphQLSchema({
   query: QueryType,

--- a/packages/spelunker-api/src/lib/graphql/index.mjs
+++ b/packages/spelunker-api/src/lib/graphql/index.mjs
@@ -1,7 +1,7 @@
 // This is required to work around co-existing CJS and ESM packages
 // See: https://github.com/graphql/express-graphql/issues/425
 // And: https://github.com/apollographql/apollo-server/issues/1035
-import graphql from './cjs-export';
+import graphql from './cjs-export.js';
 
 const {
   GraphQLBoolean,

--- a/packages/spelunker-api/src/lib/graphql/utils.mjs
+++ b/packages/spelunker-api/src/lib/graphql/utils.mjs
@@ -2,8 +2,8 @@
 
 import {
   GraphQLEnumType,
-} from '../graphql';
-import { createCache } from '../utils/cache';
+} from '../graphql/index.mjs';
+import { createCache } from '../utils/cache.mjs';
 
 const cache = createCache();
 

--- a/packages/spelunker-api/src/lib/mpq/files/GlueStrings.mjs
+++ b/packages/spelunker-api/src/lib/mpq/files/GlueStrings.mjs
@@ -1,4 +1,4 @@
-import mpq from '../';
+import mpq from '../index.mjs';
 
 const file = mpq.files.get('Interface\\GlueXML\\GlueStrings.lua');
 const source = file.data.toString();

--- a/packages/spelunker-api/src/lib/mpq/files/MinimapTiles.mjs
+++ b/packages/spelunker-api/src/lib/mpq/files/MinimapTiles.mjs
@@ -1,4 +1,4 @@
-import mpq from '../';
+import mpq from '../index.mjs';
 
 const file = mpq.files.get('textures\\Minimap\\md5translate.trs');
 const source = file.data.toString();

--- a/packages/spelunker-api/src/lib/mpq/index.mjs
+++ b/packages/spelunker-api/src/lib/mpq/index.mjs
@@ -1,4 +1,4 @@
-import MPQChain from 'blizzardry/lib/mpq/chain';
+import MPQChain from 'blizzardry/lib/mpq/chain.js';
 
 const dataDir = process.env.DATA_DIR;
 const mpq = MPQChain.build(dataDir);

--- a/packages/spelunker-api/src/lib/pipeline/index.mjs
+++ b/packages/spelunker-api/src/lib/pipeline/index.mjs
@@ -1,9 +1,9 @@
-import BLP from 'blizzardry/lib/blp';
+import BLP from 'blizzardry/lib/blp/index.js';
 import express from 'express';
 import pngjs from 'pngjs';
 
-import minimapTiles from '../mpq/files/MinimapTiles';
-import mpq from '../mpq';
+import minimapTiles from '../mpq/files/MinimapTiles.mjs';
+import mpq from '../mpq/index.mjs';
 
 const { PNG } = pngjs;
 

--- a/packages/spelunker-api/src/lib/server.mjs
+++ b/packages/spelunker-api/src/lib/server.mjs
@@ -3,9 +3,9 @@ import bodyParser from 'body-parser';
 import cors from 'cors';
 import express from 'express';
 
-import pipeline from './pipeline';
-import rootValue from './graph/root';
-import schema from './graph/schema';
+import pipeline from './pipeline/index.mjs';
+import rootValue from './graph/root.mjs';
+import schema from './graph/schema/index.mjs';
 
 const { graphqlExpress, graphiqlExpress } = apolloExpress;
 

--- a/packages/spelunker-api/src/lib/utils/cache.mjs
+++ b/packages/spelunker-api/src/lib/utils/cache.mjs
@@ -1,4 +1,4 @@
-import logger from './logger';
+import logger from './logger.mjs';
 
 const SEPARATOR = '/';
 


### PR DESCRIPTION
This PR adjusts module specifiers for compatibility with Node 12+. All ESM imports are now specified as `.mjs`, and all CJS imports are specified as `.js`.