### PR TITLE
fix(web): use string type for side id

### DIFF
--- a/packages/spelunker-web/src/components/entities/Side/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/index.jsx
@@ -34,7 +34,7 @@ const fetchSide = gql`
 `;
 
 const Side = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+  const { id } = match.params;
   return (
     <Query query={fetchSide} variables={{ id }}>
       {({ data }) => {

--- a/packages/spelunker-web/src/components/entities/Side/tabs/Areas.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/Areas.jsx
@@ -21,7 +21,7 @@ const listAreasForSide = gql`
 `;
 
 const AreasTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+  const { id } = match.params;
   return (
     <Collection
       accessor="side.areas"

--- a/packages/spelunker-web/src/components/entities/Side/tabs/ExclusiveQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/ExclusiveQuests.jsx
@@ -21,7 +21,7 @@ const listExclusiveQuestsForSide = gql`
 `;
 
 const ExclusiveQuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+  const { id } = match.params;
   return (
     <Collection
       accessor="side.exclusiveQuests"

--- a/packages/spelunker-web/src/components/entities/Side/tabs/Quests.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/Quests.jsx
@@ -21,7 +21,7 @@ const listQuestsForSide = gql`
 `;
 
 const QuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+  const { id } = match.params;
   return (
     <Collection
       accessor="side.quests"

--- a/packages/spelunker-web/src/components/entities/Side/tabs/Races.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/Races.jsx
@@ -21,7 +21,7 @@ const listRacesForSide = gql`
 `;
 
 const RacesTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+  const { id } = match.params;
   return (
     <Collection
       accessor="side.races"


### PR DESCRIPTION
I was a little hasty in converting `id` route params to integers. It turns out we had one use of them as strings.