### PR TITLE
chore(format): allow UNSAFE-prefixed functions in camelcase eslint rule

### DIFF
--- a/packages/spelunker-web/.eslintrc
+++ b/packages/spelunker-web/.eslintrc
@@ -5,6 +5,9 @@
     "eslint-config-airbnb/rules/react-a11y"
   ],
   "rules": {
+    "camelcase": ["error", {
+      "allow": ["^UNSAFE_"]
+    }],
     "no-underscore-dangle": "off",
     "jsx-a11y/anchor-is-valid": "off",
     "react/button-has-type": "off",


### PR DESCRIPTION
This PR tweaks the `camelcase` ESLint rule to permit `UNSAFE`-prefixed function names (a la `UNSAFE_componentWillMount`).