### PR TITLE
chore(web): upgrade to react router 6

### DIFF
--- a/packages/spelunker-web/.eslintrc
+++ b/packages/spelunker-web/.eslintrc
@@ -2,7 +2,8 @@
   "extends": [
     "@wowserhq/eslint-config",
     "eslint-config-airbnb/rules/react",
-    "eslint-config-airbnb/rules/react-a11y"
+    "eslint-config-airbnb/rules/react-a11y",
+    "eslint-config-airbnb/rules/react-hooks"
   ],
   "rules": {
     "camelcase": ["error", {

--- a/packages/spelunker-web/package-lock.json
+++ b/packages/spelunker-web/package-lock.json
@@ -5692,16 +5692,11 @@
       "dev": true
     },
     "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
+      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "hmac-drbg": {
@@ -6768,15 +6763,6 @@
         "mime-db": "1.51.0"
       }
     },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7821,21 +7807,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        }
-      }
-    },
     "pbkdf2": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
@@ -8400,86 +8371,20 @@
       }
     },
     "react-router": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
-      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.2.tgz",
+      "integrity": "sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          },
-          "dependencies": {
-            "loose-envify": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            }
-          }
-        }
+        "history": "^5.1.0"
       }
     },
     "react-router-dom": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
-      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.2.tgz",
+      "integrity": "sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.1",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          },
-          "dependencies": {
-            "loose-envify": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            }
-          }
-        }
+        "history": "^5.1.0",
+        "react-router": "6.0.2"
       }
     },
     "readable-stream": {
@@ -8722,11 +8627,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -10252,16 +10152,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -10694,11 +10584,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/packages/spelunker-web/package.json
+++ b/packages/spelunker-web/package.json
@@ -32,7 +32,7 @@
     "react-apollo": "^2.4.1",
     "react-dom": "^16.14.0",
     "react-leaflet": "^2.8.0",
-    "react-router-dom": "^5.2.1"
+    "react-router-dom": "^6.0.2"
   },
   "devDependencies": {
     "@wowserhq/eslint-config": "^0.4.0",

--- a/packages/spelunker-web/src/components/Search/ResultsTab.jsx
+++ b/packages/spelunker-web/src/components/Search/ResultsTab.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import accountColumns from '../entities/Account/columns';
@@ -53,9 +54,9 @@ const ResultsTab = (props) => {
   const {
     columnsFragmentName,
     path,
-    match: { params: { query: searchQuery } },
     accessor = path,
   } = props;
+  const { query: searchQuery } = useParams();
   const columns = columnsLookup[columnsFragmentName];
   const query = resultsQueryFor(accessor, { columnsFragmentName, columns });
   // TODO: Set proper page title

--- a/packages/spelunker-web/src/components/Search/index.jsx
+++ b/packages/spelunker-web/src/components/Search/index.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import {
@@ -61,182 +62,152 @@ const search = gql`
   }
 `;
 
-class Search extends React.Component {
-  constructor(props, ...args) {
-    super(props, ...args);
+const Search = () => {
+  const [query, setQuery] = useState('');
+  const navigate = useNavigate();
+  const params = useParams();
+  const { query: submittedQuery } = params;
 
-    this.state = {
-      query: props.match.params.query || '',
-    };
-
-    this.onQueryChange = this.onQueryChange.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-  }
-
-  onQueryChange(e) {
-    this.setState({ query: e.target.value });
-  }
-
-  onSubmit(e) {
+  const onSubmit = (e) => {
     e.preventDefault();
+    navigate(`/search/${query}`);
+  };
 
-    this.props.history.push(`/search/${this.state.query}`);
-  }
+  return (
+    <Title>
+      <Box>
+        <Form onSubmit={onSubmit}>
+          <Input value={query} onChange={(e) => setQuery(e.target.value)} />
+          <Button label="Search" />
+        </Form>
+      </Box>
 
-  render() {
-    const { query } = this.state;
-    const { match } = this.props;
-    const { params: { query: submittedQuery } } = match;
-    return (
-      <Title>
-        <Box>
-          <Form onSubmit={this.onSubmit}>
-            <Input value={query} onChange={this.onQueryChange} />
-            <Button label="Search" />
-          </Form>
-        </Box>
+      {submittedQuery &&
+        <Query query={search} variables={{ searchQuery: submittedQuery }}>
+          {({ data }) => {
+            const {
+              accounts: { totalCount: accountCount },
+              areas: { totalCount: areaCount },
+              characters: { totalCount: characterCount },
+              classes: { totalCount: classCount },
+              factions: { totalCount: factionCount },
+              objects: { totalCount: objectCount },
+              items: { totalCount: itemCount },
+              itemSets: { totalCount: itemSetCount },
+              maps: { totalCount: mapCount },
+              npcs: { totalCount: npcCount },
+              quests: { totalCount: questCount },
+              races: { totalCount: raceCount },
+              sides: { totalCount: sideCount },
+              spells: { totalCount: spellCount },
+            } = data;
 
-        {submittedQuery &&
-          <Query query={search} variables={{ searchQuery: submittedQuery }}>
-            {({ data }) => {
-              const {
-                accounts: { totalCount: accountCount },
-                areas: { totalCount: areaCount },
-                characters: { totalCount: characterCount },
-                classes: { totalCount: classCount },
-                factions: { totalCount: factionCount },
-                objects: { totalCount: objectCount },
-                items: { totalCount: itemCount },
-                itemSets: { totalCount: itemSetCount },
-                maps: { totalCount: mapCount },
-                npcs: { totalCount: npcCount },
-                quests: { totalCount: questCount },
-                races: { totalCount: raceCount },
-                sides: { totalCount: sideCount },
-                spells: { totalCount: spellCount },
-              } = data;
+            return (
+              <TabbedBox>
+                {accountCount > 0 && <Tab
+                  label={`Accounts (${accountCount})`}
+                  component={ResultsTab}
+                  path="accounts"
+                  columnsFragmentName="accountColumns"
+                />}
 
-              return (
-                <TabbedBox>
-                  {accountCount > 0 && <Tab
-                    label={`Accounts (${accountCount})`}
-                    component={ResultsTab}
-                    path="accounts"
-                    match={match}
-                    columnsFragmentName="accountColumns"
-                  />}
+                {areaCount > 0 && <Tab
+                  label={`Areas (${areaCount})`}
+                  component={ResultsTab}
+                  path="areas"
+                  columnsFragmentName="areaColumns"
+                />}
 
-                  {areaCount > 0 && <Tab
-                    label={`Areas (${areaCount})`}
-                    component={ResultsTab}
-                    path="areas"
-                    match={match}
-                    columnsFragmentName="areaColumns"
-                  />}
+                {characterCount > 0 && <Tab
+                  label={`Characters (${characterCount})`}
+                  component={ResultsTab}
+                  path="characters"
+                  columnsFragmentName="characterColumns"
+                />}
 
-                  {characterCount > 0 && <Tab
-                    label={`Characters (${characterCount})`}
-                    component={ResultsTab}
-                    path="characters"
-                    match={match}
-                    columnsFragmentName="characterColumns"
-                  />}
+                {classCount > 0 && <Tab
+                  label={`Classes (${classCount})`}
+                  component={ResultsTab}
+                  path="classes"
+                  columnsFragmentName="classColumns"
+                />}
 
-                  {classCount > 0 && <Tab
-                    label={`Classes (${classCount})`}
-                    component={ResultsTab}
-                    path="classes"
-                    match={match}
-                    columnsFragmentName="classColumns"
-                  />}
+                {factionCount > 0 && <Tab
+                  label={`Factions (${factionCount})`}
+                  component={ResultsTab}
+                  path="factions"
+                  columnsFragmentName="factionColumns"
+                />}
 
-                  {factionCount > 0 && <Tab
-                    label={`Factions (${factionCount})`}
-                    component={ResultsTab}
-                    path="factions"
-                    match={match}
-                    columnsFragmentName="factionColumns"
-                  />}
+                {objectCount > 0 && <Tab
+                  label={`Objects (${objectCount})`}
+                  component={ResultsTab}
+                  path="objects"
+                  columnsFragmentName="gameObjectColumns"
+                />}
 
-                  {objectCount > 0 && <Tab
-                    label={`Objects (${objectCount})`}
-                    component={ResultsTab}
-                    path="objects"
-                    match={match}
-                    columnsFragmentName="gameObjectColumns"
-                  />}
+                {itemCount > 0 && <Tab
+                  label={`Items (${itemCount})`}
+                  component={ResultsTab}
+                  path="items"
+                  columnsFragmentName="itemColumns"
+                />}
 
-                  {itemCount > 0 && <Tab
-                    label={`Items (${itemCount})`}
-                    component={ResultsTab}
-                    path="items"
-                    match={match}
-                    columnsFragmentName="itemColumns"
-                  />}
+                {itemSetCount > 0 && <Tab
+                  label={`Item Sets (${itemSetCount})`}
+                  component={ResultsTab}
+                  path="item-sets"
+                  accessor="itemSets"
+                  columnsFragmentName="itemSetColumns"
+                />}
 
-                  {itemSetCount > 0 && <Tab
-                    label={`Item Sets (${itemSetCount})`}
-                    component={ResultsTab}
-                    path="item-sets"
-                    match={match}
-                    accessor="itemSets"
-                    columnsFragmentName="itemSetColumns"
-                  />}
+                {mapCount > 0 && <Tab
+                  label={`Maps (${mapCount})`}
+                  component={ResultsTab}
+                  path="maps"
+                  columnsFragmentName="mapColumns"
+                />}
 
-                  {mapCount > 0 && <Tab
-                    label={`Maps (${mapCount})`}
-                    component={ResultsTab}
-                    path="maps"
-                    match={match}
-                    columnsFragmentName="mapColumns"
-                  />}
+                {npcCount > 0 && <Tab
+                  label={`NPCs (${npcCount})`}
+                  component={ResultsTab}
+                  path="npcs"
+                  columnsFragmentName="npcColumns"
+                />}
 
-                  {npcCount > 0 && <Tab
-                    label={`NPCs (${npcCount})`}
-                    component={ResultsTab}
-                    path="npcs"
-                    match={match}
-                    columnsFragmentName="npcColumns"
-                  />}
+                {questCount > 0 && <Tab
+                  label={`Quests (${questCount})`}
+                  component={ResultsTab}
+                  path="quests"
+                  columnsFragmentName="questColumns"
+                />}
 
-                  {questCount > 0 && <Tab
-                    label={`Quests (${questCount})`}
-                    component={ResultsTab}
-                    path="quests"
-                    match={match}
-                    columnsFragmentName="questColumns"
-                  />}
+                {raceCount > 0 && <Tab
+                  label={`Races (${raceCount})`}
+                  component={ResultsTab}
+                  path="races"
+                  columnsFragmentName="raceColumns"
+                />}
 
-                  {raceCount > 0 && <Tab
-                    label={`Races (${raceCount})`}
-                    component={ResultsTab}
-                    path="races"
-                    match={match}
-                    columnsFragmentName="raceColumns"
-                  />}
+                {sideCount > 0 && <Tab
+                  label={`Sides (${sideCount})`}
+                  component={ResultsTab}
+                  path="sides"
+                  columnsFragmentName="sideColumns"
+                />}
 
-                  {sideCount > 0 && <Tab
-                    label={`Sides (${sideCount})`}
-                    component={ResultsTab}
-                    path="sides"
-                    match={match}
-                    columnsFragmentName="sideColumns"
-                  />}
-
-                  {spellCount > 0 && <Tab
-                    label={`Spells (${spellCount})`}
-                    component={ResultsTab}
-                    path="spells"
-                    match={match}
-                    columnsFragmentName="spellColumns"
-                  />}
-                </TabbedBox>
-              );
-            }}
-          </Query>}
-      </Title>
-    );
-  }
-}
+                {spellCount > 0 && <Tab
+                  label={`Spells (${spellCount})`}
+                  component={ResultsTab}
+                  path="spells"
+                  columnsFragmentName="spellColumns"
+                />}
+              </TabbedBox>
+            );
+          }}
+        </Query>}
+    </Title>
+  );
+};
 
 export default Search;

--- a/packages/spelunker-web/src/components/Spelunker/index.jsx
+++ b/packages/spelunker-web/src/components/Spelunker/index.jsx
@@ -4,7 +4,7 @@ import {
   BrowserRouter as Router,
   NavLink,
   Route,
-  Switch,
+  Routes,
 } from 'react-router-dom';
 
 import Account from '../entities/Account';
@@ -49,7 +49,7 @@ const Spelunker = () => (
         <header className={styles.header}>
           <nav>
             <ul>
-              <li><NavLink exact to="/">Spelunker</NavLink></li>
+              <li><NavLink end to="/">Spelunker</NavLink></li>
               <li><NavLink to="/accounts">Accounts</NavLink></li>
               <li><NavLink to="/areas">Areas</NavLink></li>
               <li><NavLink to="/characters">Characters</NavLink></li>
@@ -67,51 +67,82 @@ const Spelunker = () => (
           </nav>
         </header>
 
-        <Switch>
-          <Route path="/accounts/:id" component={Account} />
-          <Route path="/accounts" component={AccountList} />
+        <Routes>
+          <Route path="/accounts">
+            <Route path=":id/*" element={<Account />} />
+            <Route index element={<AccountList />} />
+          </Route>
 
-          <Route path="/areas/:id" component={Area} />
-          <Route path="/areas" component={AreaList} />
+          <Route path="/areas">
+            <Route path=":id/*" element={<Area />} />
+            <Route index element={<AreaList />} />
+          </Route>
 
-          <Route path="/characters/:id" component={Character} />
-          <Route path="/characters" component={CharacterList} />
+          <Route path="/characters">
+            <Route path=":id/*" element={<Character />} />
+            <Route index element={<CharacterList />} />
+          </Route>
 
-          <Route path="/classes/:id" component={Class} />
-          <Route path="/classes" component={ClassList} />
+          <Route path="/classes">
+            <Route path=":id/*" element={<Class />} />
+            <Route index element={<ClassList />} />
+          </Route>
 
-          <Route path="/factions/:id" component={Faction} />
-          <Route path="/factions" component={FactionList} />
+          <Route path="/factions">
+            <Route path=":id/*" element={<Faction />} />
+            <Route index element={<FactionList />} />
+          </Route>
 
-          <Route path="/items/:id" component={Item} />
-          <Route path="/items" component={ItemList} />
+          <Route path="/items">
+            <Route path=":id/*" element={<Item />} />
+            <Route index element={<ItemList />} />
+          </Route>
 
-          <Route path="/item-sets/:id" component={ItemSet} />
-          <Route path="/item-sets" component={ItemSetList} />
+          <Route path="/item-sets">
+            <Route path=":id/*" element={<ItemSet />} />
+            <Route index element={<ItemSetList />} />
+          </Route>
 
-          <Route path="/maps/:id" component={Map} />
-          <Route path="/maps" component={MapList} />
+          <Route path="/maps">
+            <Route path=":id/*" element={<Map />} />
+            <Route index element={<MapList />} />
+          </Route>
 
-          <Route path="/npcs/:id" component={NPC} />
-          <Route path="/npcs" component={NPCList} />
+          <Route path="/npcs">
+            <Route path=":id/*" element={<NPC />} />
+            <Route index element={<NPCList />} />
+          </Route>
 
-          <Route path="/objects/:id" component={GameObject} />
-          <Route path="/objects" component={GameObjectList} />
+          <Route path="/objects">
+            <Route path=":id/*" element={<GameObject />} />
+            <Route index element={<GameObjectList />} />
+          </Route>
 
-          <Route path="/quests/:id" component={Quest} />
-          <Route path="/quests" component={QuestList} />
+          <Route path="/quests">
+            <Route path=":id/*" element={<Quest />} />
+            <Route index element={<QuestList />} />
+          </Route>
 
-          <Route path="/races/:id" component={Race} />
-          <Route path="/races" component={RaceList} />
+          <Route path="/races">
+            <Route path=":id/*" element={<Race />} />
+            <Route index element={<RaceList />} />
+          </Route>
 
-          <Route path="/sides/:id" component={Side} />
+          <Route path="/sides">
+            <Route path=":id/*" element={<Side />} />
+          </Route>
 
-          <Route path="/spells/:id" component={Spell} />
-          <Route path="/spells" component={SpellList} />
+          <Route path="/spells">
+            <Route path=":id/*" element={<Spell />} />
+            <Route index element={<SpellList />} />
+          </Route>
 
-          <Route path="/search/:query?" component={Search} />
-          <Route path="/" exact component={Search} />
-        </Switch>
+          <Route path="/search">
+            <Route path=":query/*" element={<Search />} />
+          </Route>
+
+          <Route path="/" end element={<Search />} />
+        </Routes>
 
         <footer className={styles.footer}>
           <ProjectLink /> · &copy;2018-2021 Wowser Contributors

--- a/packages/spelunker-web/src/components/core/Box/Tabbed/Tab.jsx
+++ b/packages/spelunker-web/src/components/core/Box/Tabbed/Tab.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 
 const Tab = (props) => {
-  if (!props.active) {
-    return null;
-  }
-
   const Component = props.component;
   return <Component {...props} />;
 };

--- a/packages/spelunker-web/src/components/core/Box/Tabbed/index.jsx
+++ b/packages/spelunker-web/src/components/core/Box/Tabbed/index.jsx
@@ -1,60 +1,49 @@
 import React from 'react';
-import { Link, matchPath, withRouter } from 'react-router-dom';
+import { Link, Route, Routes, useLocation, useResolvedPath } from 'react-router-dom';
 
 import styles from './index.styl';
 
+const TabNav = ({ path, label, index }) => {
+  const location = useLocation();
+  const resolvedPath = useResolvedPath(path);
+  const activeByPath = resolvedPath.pathname === location.pathname;
+  const activeByDefault = index === 0 && location.pathname.split('/').length < resolvedPath.pathname.split('/').length;
+  const active = activeByPath || activeByDefault;
+
+  return (
+    <li className={active ? styles.active : null}>
+      <Link to={path}>
+        <span className={styles.label}>{label}</span>
+        <span className={styles.corners} />
+      </Link>
+    </li>
+  );
+};
+
 const TabbedBox = (props) => {
-  const children = React.Children.toArray(props.children);
-  if (!children.length) {
+  const tabs = React.Children.toArray(props.children);
+  if (!tabs.length) {
     return null;
   }
 
-  const { history, location } = props;
-
-  let match = false;
-  const tabs = children.map(child => {
-    const active = matchPath(
-      location.pathname,
-      { path: `${child.props.match.path}/${child.props.path}` },
-    );
-
-    if (active) {
-      match = true;
-    }
-
-    return React.cloneElement(
-      child,
-      {
-        target: `${child.props.match.url}/${child.props.path}`,
-        active,
-      },
-    );
-  });
-
-  if (!match) {
-    history.replace(tabs[0].props.target);
-    return null;
-  }
+  const tabRoutes = tabs.map(tab => (
+    <Route key={tab.props.path} path={tab.props.path} element={tab} />
+  ));
 
   return (
     <div className={styles.tabbed}>
       <ul className={styles.tabs}>
-        {tabs.map(tab => (
-          <li
-            key={tab.props.label}
-            className={tab.props.active ? styles.active : null}
-          >
-            <Link to={`${tab.props.match.url}/${tab.props.path}`}>
-              <span className={styles.label}>{tab.props.label}</span>
-              <span className={styles.corners} />
-            </Link>
-          </li>
+        {tabs.map((tab, index) => (
+          <TabNav key={tab.props.path} {...tab.props} index={index} />
         ))}
       </ul>
 
-      {tabs}
+      <Routes>
+        {tabRoutes}
+        <Route index element={tabs[0]} />
+      </Routes>
     </div>
   );
 };
 
-export default withRouter(TabbedBox);
+export default TabbedBox;

--- a/packages/spelunker-web/src/components/core/Collection/index.jsx
+++ b/packages/spelunker-web/src/components/core/Collection/index.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { withRouter } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import Pagination from '../Pagination';
 import Query from '../Query';
 import valueByPath from '../../../utils/valueByPath';
 
 const Collection = (props) => {
-  const { location } = props;
+  const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const offset = +queryParams.get('offset') || 0;
   const variables = Object.assign({}, props.variables, { offset });
@@ -38,4 +38,4 @@ const Collection = (props) => {
   );
 };
 
-export default withRouter(Collection);
+export default Collection;

--- a/packages/spelunker-web/src/components/entities/Account/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Account/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import { Box, Query, Tab, TabbedBox, Title } from '../../core';
@@ -20,8 +21,9 @@ const fetchAccount = gql`
   ${AccountReference.fragment}
 `;
 
-const Account = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Account = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchAccount} variables={{ id }}>
       {({ data }) => {
@@ -45,7 +47,6 @@ const Account = ({ match }) => {
                 label={`Characters (${characterCount})`}
                 component={CharactersTab}
                 path="characters"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Account/tabs/Characters.jsx
+++ b/packages/spelunker-web/src/components/entities/Account/tabs/Characters.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import { Collection, Table } from '../../../core';
@@ -20,8 +21,9 @@ const listCharactersForAccount = gql`
   ${characterColumns.fragment}
 `;
 
-const CharactersTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const CharactersTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="account.characters"

--- a/packages/spelunker-web/src/components/entities/Area/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Area/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import {
@@ -51,8 +52,9 @@ const fetchArea = gql`
   ${MapReference.fragment}
 `;
 
-const Area = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Area = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchArea} variables={{ id }}>
       {({ data }) => {
@@ -102,14 +104,12 @@ const Area = ({ match }) => {
                 label={`Sub-areas (${subareaCount})`}
                 component={SubareasTab}
                 path="sub-areas"
-                match={match}
               />}
 
               {questCount > 0 && <Tab
                 label={`Quests (${questCount})`}
                 component={QuestsTab}
                 path="quests"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Area/tabs/Quests.jsx
+++ b/packages/spelunker-web/src/components/entities/Area/tabs/Quests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listQuestsForArea = gql`
   ${questColumns.fragment}
 `;
 
-const QuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const QuestsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="area.quests"

--- a/packages/spelunker-web/src/components/entities/Area/tabs/Subareas.jsx
+++ b/packages/spelunker-web/src/components/entities/Area/tabs/Subareas.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import areaColumns from '../columns';
@@ -20,8 +21,9 @@ const listSubareasForArea = gql`
   ${areaColumns.fragment}
 `;
 
-const SubareasTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const SubareasTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="area.subareas"

--- a/packages/spelunker-web/src/components/entities/Character/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import AccountReference from '../Account/Reference';
@@ -84,8 +85,9 @@ const fetchCharacter = gql`
   ${CharacterReference.fragment}
 `;
 
-const Character = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Character = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchCharacter} variables={{ id }}>
       {({ data }) => {
@@ -128,35 +130,30 @@ const Character = ({ match }) => {
                 label={`Inventory (${inventoryCount})`}
                 component={InventoryTab}
                 path="inventory"
-                match={match}
               />}
 
               {currentQuestCount > 0 && <Tab
                 label={`Current quests (${currentQuestCount})`}
                 component={CurrentQuestsTab}
                 path="current-quests"
-                match={match}
               />}
 
               {completedQuestCount > 0 && <Tab
                 label={`Completed quests (${completedQuestCount})`}
                 component={CompletedQuestsTab}
                 path="completed-quests"
-                match={match}
               />}
 
               {uncompletedQuestCount > 0 && <Tab
                 label={`Uncompleted quests (${uncompletedQuestCount})`}
                 component={UncompletedQuestsTab}
                 path="uncompleted-quests"
-                match={match}
               />}
 
               {reputationCount > 0 && <Tab
                 label={`Reputation (${reputationCount})`}
                 component={ReputationTab}
                 path="reputation"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Character/tabs/CompletedQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/CompletedQuests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listCompletedQuestsForCharacter = gql`
   ${questColumns.fragment}
 `;
 
-const CompletedQuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const CompletedQuestsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="character.completedQuests"

--- a/packages/spelunker-web/src/components/entities/Character/tabs/CurrentQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/CurrentQuests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -23,8 +24,9 @@ const listCurrentQuestsForCharacter = gql`
   ${questColumns.fragment}
 `;
 
-const CurrentQuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const CurrentQuestsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="character.currentQuests"

--- a/packages/spelunker-web/src/components/entities/Character/tabs/Inventory.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/Inventory.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import itemColumns from '../../Item/columns';
@@ -24,8 +25,9 @@ const listInventoryForCharacter = gql`
   ${itemColumns.fragment}
 `;
 
-const InventoryTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const InventoryTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="character.inventory"

--- a/packages/spelunker-web/src/components/entities/Character/tabs/Reputation.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/Reputation.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import factionColumns from '../../Faction/columns';
@@ -23,8 +24,9 @@ const listReputationForCharacter = gql`
   ${factionColumns.fragment}
 `;
 
-const ReputationTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ReputationTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="character.reputation"

--- a/packages/spelunker-web/src/components/entities/Character/tabs/UncompletedQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/UncompletedQuests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listUncompletedQuestsForCharacter = gql`
   ${questColumns.fragment}
 `;
 
-const UncompletedQuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const UncompletedQuestsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="character.uncompletedQuests"

--- a/packages/spelunker-web/src/components/entities/Class/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import { Box, Query, Tab, TabbedBox, Title } from '../../core';
@@ -29,8 +30,9 @@ const fetchClass = gql`
   ${ClassReference.fragment}
 `;
 
-const Class = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Class = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchClass} variables={{ id }}>
       {({ data }) => {
@@ -60,21 +62,18 @@ const Class = ({ match }) => {
                 label={`Races (${raceCount})`}
                 component={RacesTab}
                 path="races"
-                match={match}
               />}
 
               {exclusiveQuestCount > 0 && <Tab
                 label={`Exclusive quests (${exclusiveQuestCount})`}
                 component={ExclusiveQuestsTab}
                 path="exclusive-quests"
-                match={match}
               />}
 
               {questCount > 0 && <Tab
                 label={`Quests (${questCount})`}
                 component={QuestsTab}
                 path="quests"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Class/tabs/ExclusiveQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/tabs/ExclusiveQuests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listExclusiveQuestsForClass = gql`
   ${questColumns.fragment}
 `;
 
-const ExclusiveQuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ExclusiveQuestsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="class.exclusiveQuests"

--- a/packages/spelunker-web/src/components/entities/Class/tabs/Quests.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/tabs/Quests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listQuestsForClass = gql`
   ${questColumns.fragment}
 `;
 
-const QuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const QuestsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="class.quests"

--- a/packages/spelunker-web/src/components/entities/Class/tabs/Races.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/tabs/Races.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import raceColumns from '../../Race/columns';
@@ -20,8 +21,9 @@ const listRacesForClass = gql`
   ${raceColumns.fragment}
 `;
 
-const RacesTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const RacesTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="class.races"

--- a/packages/spelunker-web/src/components/entities/Faction/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Faction/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import { Box, Query, List, ListItem, Tab, TabbedBox, Title } from '../../core';
@@ -29,8 +30,9 @@ const fetchFaction = gql`
   ${FactionReference.fragment}
 `;
 
-const Faction = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Faction = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchFaction} variables={{ id }}>
       {({ data }) => {
@@ -67,14 +69,12 @@ const Faction = ({ match }) => {
                 label={`Sub-factions (${subfactionCount})`}
                 component={SubfactionsTab}
                 path="sub-factions"
-                match={match}
               />}
 
               {objectiveOfCount > 0 && <Tab
                 label={`Objective of (${objectiveOfCount})`}
                 component={ObjectiveOfTab}
                 path="objective-of"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Faction/tabs/ObjectiveOf.jsx
+++ b/packages/spelunker-web/src/components/entities/Faction/tabs/ObjectiveOf.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listObjectiveOfForFaction = gql`
   ${questColumns.fragment}
 `;
 
-const ObjectiveOfTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ObjectiveOfTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="faction.objectiveOf"

--- a/packages/spelunker-web/src/components/entities/Faction/tabs/Subfactions.jsx
+++ b/packages/spelunker-web/src/components/entities/Faction/tabs/Subfactions.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import factionColumns from '../columns';
@@ -20,8 +21,9 @@ const listSubfactionsForFaction = gql`
   ${factionColumns.fragment}
 `;
 
-const SubfactionsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const SubfactionsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="faction.subfactions"

--- a/packages/spelunker-web/src/components/entities/GameObject/index.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import LocationSelector from '../Location/Selector';
@@ -80,8 +81,9 @@ const fetchGameObject = gql`
   ${GameObjectReference.fragment}
 `;
 
-const GameObject = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const GameObject = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchGameObject} variables={{ id }}>
       {({ data }) => {
@@ -121,28 +123,24 @@ const GameObject = ({ match }) => {
                 label={`Contains (${containCount})`}
                 component={ContainsTab}
                 path="contains"
-                match={match}
               />}
 
               {startCount > 0 && <Tab
                 label={`Starts (${startCount})`}
                 component={StartsTab}
                 path="starts"
-                match={match}
               />}
 
               {endCount > 0 && <Tab
                 label={`Ends (${endCount})`}
                 component={EndsTab}
                 path="ends"
-                match={match}
               />}
 
               {objectiveOfCount > 0 && <Tab
                 label={`Objective of (${objectiveOfCount})`}
                 component={ObjectiveOfTab}
                 path="objective-of"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/GameObject/tabs/Contains.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/tabs/Contains.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import itemColumns from '../../Item/columns';
@@ -23,8 +24,9 @@ const listContainsForGameObject = gql`
   ${itemColumns.fragment}
 `;
 
-const ContainsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ContainsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="object.contains"

--- a/packages/spelunker-web/src/components/entities/GameObject/tabs/Ends.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/tabs/Ends.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listEndsForGameObject = gql`
   ${questColumns.fragment}
 `;
 
-const EndsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const EndsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="object.ends"

--- a/packages/spelunker-web/src/components/entities/GameObject/tabs/ObjectiveOf.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/tabs/ObjectiveOf.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listObjectiveOfForGameObject = gql`
   ${questColumns.fragment}
 `;
 
-const ObjectiveOfTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ObjectiveOfTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="object.objectiveOf"

--- a/packages/spelunker-web/src/components/entities/GameObject/tabs/Starts.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/tabs/Starts.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listStartsForGameObject = gql`
   ${questColumns.fragment}
 `;
 
-const StartsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const StartsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="object.starts"

--- a/packages/spelunker-web/src/components/entities/Item/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import Currency from '../../formatters/Currency';
@@ -60,8 +61,9 @@ const fetchItem = gql`
   ${ItemSetReference.fragment}
 `;
 
-const Item = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Item = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchItem} variables={{ id }}>
       {({ data }) => {
@@ -113,63 +115,54 @@ const Item = ({ match }) => {
                 label={`Dropped by (${droppedByCount})`}
                 component={DroppedByTab}
                 path="dropped-by"
-                match={match}
               />}
 
               {containedInCount > 0 && <Tab
                 label={`Contained in (${containedInCount})`}
                 component={ContainedInTab}
                 path="contained-in"
-                match={match}
               />}
 
               {containedInObjectCount > 0 && <Tab
                 label={`Contained in object (${containedInObjectCount})`}
                 component={ContainedInObjectTab}
                 path="contained-in-object"
-                match={match}
               />}
 
               {containCount > 0 && <Tab
                 label={`Contains (${containCount})`}
                 component={ContainsTab}
                 path="contains"
-                match={match}
               />}
 
               {objectiveOfCount > 0 && <Tab
                 label={`Objective of (${objectiveOfCount})`}
                 component={ObjectiveOfTab}
                 path="objective-of"
-                match={match}
               />}
 
               {providedForCount > 0 && <Tab
                 label={`Provided for (${providedForCount})`}
                 component={ProvidedForTab}
                 path="provided-for"
-                match={match}
               />}
 
               {rewardFromCount > 0 && <Tab
                 label={`Reward from (${rewardFromCount})`}
                 component={RewardFromTab}
                 path="reward-from"
-                match={match}
               />}
 
               {soldByCount > 0 && <Tab
                 label={`Sold by (${soldByCount})`}
                 component={SoldByTab}
                 path="sold-by"
-                match={match}
               />}
 
               {startCount > 0 && <Tab
                 label={`Starts (${startCount})`}
                 component={StartsTab}
                 path="starts"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Item/tabs/ContainedIn.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/ContainedIn.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import itemColumns from '../columns';
@@ -28,8 +29,9 @@ const listContainedInForItem = gql`
   ${itemColumns.fragment}
 `;
 
-const ContainedInTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ContainedInTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="item.containedIn"

--- a/packages/spelunker-web/src/components/entities/Item/tabs/ContainedInObject.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/ContainedInObject.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import gameObjectColumns from '../../GameObject/columns';
@@ -28,8 +29,9 @@ const listContainedInObjectForItem = gql`
   ${gameObjectColumns.fragment}
 `;
 
-const ContainedInObjectTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ContainedInObjectTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="item.containedInObject"

--- a/packages/spelunker-web/src/components/entities/Item/tabs/Contains.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/Contains.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import itemColumns from '../columns';
@@ -28,8 +29,9 @@ const listContainsForItem = gql`
   ${itemColumns.fragment}
 `;
 
-const ContainsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ContainsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="item.contains"

--- a/packages/spelunker-web/src/components/entities/Item/tabs/DroppedBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/DroppedBy.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import npcColumns from '../../NPC/columns';
@@ -28,8 +29,9 @@ const listDroppedByForItem = gql`
   ${npcColumns.fragment}
 `;
 
-const DroppedByTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const DroppedByTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="item.droppedBy"

--- a/packages/spelunker-web/src/components/entities/Item/tabs/ObjectiveOf.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/ObjectiveOf.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listObjectiveOfForItem = gql`
   ${questColumns.fragment}
 `;
 
-const ObjectiveOfTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ObjectiveOfTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="item.objectiveOf"

--- a/packages/spelunker-web/src/components/entities/Item/tabs/ProvidedFor.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/ProvidedFor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listProvidedForForItem = gql`
   ${questColumns.fragment}
 `;
 
-const ProvidedForTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ProvidedForTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="item.providedFor"

--- a/packages/spelunker-web/src/components/entities/Item/tabs/RewardFrom.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/RewardFrom.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listRewardFromForItem = gql`
   ${questColumns.fragment}
 `;
 
-const RewardFromTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const RewardFromTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="item.rewardFrom"

--- a/packages/spelunker-web/src/components/entities/Item/tabs/SoldBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/SoldBy.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import npcColumns from '../../NPC/columns';
@@ -29,8 +30,9 @@ const listSoldByForItem = gql`
   ${npcColumns.fragment}
 `;
 
-const SoldByTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const SoldByTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="item.soldBy"

--- a/packages/spelunker-web/src/components/entities/Item/tabs/Starts.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/Starts.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listStartsForItem = gql`
   ${questColumns.fragment}
 `;
 
-const StartsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const StartsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="item.starts"

--- a/packages/spelunker-web/src/components/entities/ItemSet/index.jsx
+++ b/packages/spelunker-web/src/components/entities/ItemSet/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import ItemReference from '../Item/Reference';
@@ -23,8 +24,9 @@ const fetchItemSet = gql`
   ${ItemSetReference.fragment}
 `;
 
-const Item = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Item = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchItemSet} variables={{ id }}>
       {({ data }) => {

--- a/packages/spelunker-web/src/components/entities/Map/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import { Bounds, Box, GameMap, Query, Tab, TabbedBox, Title } from '../../core';
@@ -33,8 +34,9 @@ const fetchMap = gql`
   ${MapReference.fragment}
 `;
 
-const Map = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Map = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchMap} variables={{ id }}>
       {({ data }) => {
@@ -66,21 +68,18 @@ const Map = ({ match }) => {
                 label={`Areas (${areaCount})`}
                 component={AreasTab}
                 path="areas"
-                match={match}
               />}
 
               {npcSpawnCount > 0 && <Tab
                 label={`NPCs (${npcSpawnCount})`}
                 component={NPCSpawnsTab}
                 path="npcs"
-                match={match}
               />}
 
               {objectSpawnCount > 0 && <Tab
                 label={`Objects (${objectSpawnCount})`}
                 component={GameObjectSpawnsTab}
                 path="objects"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Map/tabs/Areas.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/tabs/Areas.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import { Collection, Table } from '../../../core';
@@ -20,8 +21,9 @@ const listAreasForMap = gql`
   ${areaColumns.fragment}
 `;
 
-const AreasTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const AreasTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="map.areas"

--- a/packages/spelunker-web/src/components/entities/Map/tabs/GameObjectSpawns.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/tabs/GameObjectSpawns.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import GameObjectReference from '../../GameObject/Reference';
@@ -27,8 +28,9 @@ const listObjectSpawnsForMap = gql`
   ${GameObjectReference.fragment}
 `;
 
-const GameObjectSpawnsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const GameObjectSpawnsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="map.objectSpawns"

--- a/packages/spelunker-web/src/components/entities/Map/tabs/NPCSpawns.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/tabs/NPCSpawns.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import NPCReference from '../../NPC/Reference';
@@ -33,8 +34,9 @@ const listNPCSpawnsForMap = gql`
   ${NPCReference.fragment}
 `;
 
-const NPCSpawnsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const NPCSpawnsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="map.npcSpawns"

--- a/packages/spelunker-web/src/components/entities/NPC/index.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import LocationSelector from '../Location/Selector';
@@ -84,8 +85,9 @@ const fetchNPC = gql`
   ${NPCReference.fragment}
 `;
 
-const NPC = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const NPC = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchNPC} variables={{ id }}>
       {({ data }) => {
@@ -122,42 +124,36 @@ const NPC = ({ match }) => {
                 label={`Drops (${dropCount})`}
                 component={DropsTab}
                 path="drops"
-                match={match}
               />}
 
               {sellCount > 0 && <Tab
                 label={`Sells (${sellCount})`}
                 component={SellsTab}
                 path="sells"
-                match={match}
               />}
 
               {startCount > 0 && <Tab
                 label={`Starts (${startCount})`}
                 component={StartsTab}
                 path="starts"
-                match={match}
               />}
 
               {endCount > 0 && <Tab
                 label={`Ends (${endCount})`}
                 component={EndsTab}
                 path="ends"
-                match={match}
               />}
 
               {objectiveOfCount > 0 && <Tab
                 label={`Objective of (${objectiveOfCount})`}
                 component={ObjectiveOfTab}
                 path="objective-of"
-                match={match}
               />}
 
               {teachCount > 0 && <Tab
                 label={`Teaches (${teachCount})`}
                 component={TeachesTab}
                 path="teaches"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Drops.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Drops.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import itemColumns from '../../Item/columns';
@@ -28,8 +29,9 @@ const listDropsForNPC = gql`
   ${itemColumns.fragment}
 `;
 
-const DropsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const DropsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="npc.drops"

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Ends.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Ends.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listEndsForNPC = gql`
   ${questColumns.fragment}
 `;
 
-const EndsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const EndsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="npc.ends"

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/ObjectiveOf.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/ObjectiveOf.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listObjectiveOfForNPC = gql`
   ${questColumns.fragment}
 `;
 
-const ObjectiveOfTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ObjectiveOfTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="npc.objectiveOf"

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Sells.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Sells.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import itemColumns from '../../Item/columns';
@@ -31,8 +32,9 @@ const listSellsForNPC = gql`
   ${itemColumns.fragment}
 `;
 
-const SellsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const SellsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="npc.sells"

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Starts.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Starts.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listStartsForNPC = gql`
   ${questColumns.fragment}
 `;
 
-const StartsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const StartsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="npc.starts"

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Teaches.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Teaches.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import spellColumns from '../../Spell/columns';
@@ -28,8 +29,9 @@ const listTeachesForNPC = gql`
   ${spellColumns.fragment}
 `;
 
-const TeachesTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const TeachesTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="npc.teaches"

--- a/packages/spelunker-web/src/components/entities/Quest/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import ClassReference from '../Class/Reference';
@@ -181,8 +182,9 @@ const fetchQuest = gql`
   ${SpellReference.fragment}
 `;
 
-const Quest = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Quest = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchQuest} variables={{ id }}>
       {({ data }) => {
@@ -439,35 +441,30 @@ const Quest = ({ match }) => {
                 label={`Started by (${startedByCount})`}
                 component={StartedByTab}
                 path="started-by"
-                match={match}
               />}
 
               {startedByObjectCount > 0 && <Tab
                 label={`Started by object (${startedByObjectCount})`}
                 component={StartedByObjectTab}
                 path="started-by-object"
-                match={match}
               />}
 
               {startedByItemCount > 0 && <Tab
                 label={`Started by item (${startedByItemCount})`}
                 component={StartedByItemTab}
                 path="started-by-item"
-                match={match}
               />}
 
               {endedByCount > 0 && <Tab
                 label={`Ended by (${endedByCount})`}
                 component={EndedByTab}
                 path="ended-by"
-                match={match}
               />}
 
               {endedByObjectCount > 0 && <Tab
                 label={`Ended by object (${endedByObjectCount})`}
                 component={EndedByObjectTab}
                 path="ended-by-object"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/EndedBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/EndedBy.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import npcColumns from '../../NPC/columns';
@@ -20,8 +21,9 @@ const listEndedByForQuest = gql`
   ${npcColumns.fragment}
 `;
 
-const EndedByTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const EndedByTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="quest.endedBy"

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/EndedByObject.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/EndedByObject.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import gameObjectColumns from '../../GameObject/columns';
@@ -20,8 +21,9 @@ const listEndedByObjectForQuest = gql`
   ${gameObjectColumns.fragment}
 `;
 
-const EndedByObjectTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const EndedByObjectTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="quest.endedByObject"

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/StartedBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/StartedBy.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import npcColumns from '../../NPC/columns';
@@ -20,8 +21,9 @@ const listStartedByForQuest = gql`
   ${npcColumns.fragment}
 `;
 
-const StartedByTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const StartedByTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="quest.startedBy"

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/StartedByItem.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/StartedByItem.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import itemColumns from '../../Item/columns';
@@ -20,8 +21,9 @@ const listStartedByItemForQuest = gql`
   ${itemColumns.fragment}
 `;
 
-const StartedByItemTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const StartedByItemTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="quest.startedByItem"

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/StartedByObject.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/StartedByObject.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import gameObjectColumns from '../../GameObject/columns';
@@ -20,8 +21,9 @@ const listStartedByObjectForQuest = gql`
   ${gameObjectColumns.fragment}
 `;
 
-const StartedByObjectTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const StartedByObjectTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="quest.startedByObject"

--- a/packages/spelunker-web/src/components/entities/Race/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import SideReference from '../Side/Reference';
@@ -34,8 +35,9 @@ const fetchRace = gql`
   ${SideReference.fragment}
 `;
 
-const Race = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Race = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchRace} variables={{ id }}>
       {({ data }) => {
@@ -72,21 +74,18 @@ const Race = ({ match }) => {
                 label={`Classes (${classCount})`}
                 component={ClassesTab}
                 path="classes"
-                match={match}
               />}
 
               {exclusiveQuestCount > 0 && <Tab
                 label={`Exclusive quests (${exclusiveQuestCount})`}
                 component={ExclusiveQuestsTab}
                 path="exclusive-quests"
-                match={match}
               />}
 
               {questCount > 0 && <Tab
                 label={`Quests (${questCount})`}
                 component={QuestsTab}
                 path="quests"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Race/tabs/Classes.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/tabs/Classes.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import classColumns from '../../Class/columns';
@@ -20,8 +21,9 @@ const listClassesForRace = gql`
   ${classColumns.fragment}
 `;
 
-const ClassesTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ClassesTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="race.classes"

--- a/packages/spelunker-web/src/components/entities/Race/tabs/ExclusiveQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/tabs/ExclusiveQuests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listExclusiveQuestsForRace = gql`
   ${questColumns.fragment}
 `;
 
-const ExclusiveQuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ExclusiveQuestsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="race.exclusiveQuests"

--- a/packages/spelunker-web/src/components/entities/Race/tabs/Quests.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/tabs/Quests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listQuestsForRace = gql`
   ${questColumns.fragment}
 `;
 
-const QuestsTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const QuestsTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="race.quests"

--- a/packages/spelunker-web/src/components/entities/Side/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import { Box, Query, Tab, TabbedBox, Title } from '../../core';
@@ -33,8 +34,9 @@ const fetchSide = gql`
   ${SideReference.fragment}
 `;
 
-const Side = ({ match }) => {
-  const { id } = match.params;
+const Side = () => {
+  const params = useParams();
+  const { id } = params;
   return (
     <Query query={fetchSide} variables={{ id }}>
       {({ data }) => {
@@ -66,28 +68,24 @@ const Side = ({ match }) => {
                 label={`Races (${raceCount})`}
                 component={RacesTab}
                 path="races"
-                match={match}
               />}
 
               {areaCount > 0 && <Tab
                 label={`Areas (${areaCount})`}
                 component={AreasTab}
                 path="areas"
-                match={match}
               />}
 
               {exclusiveQuestCount > 0 && <Tab
                 label={`Exclusive quests (${exclusiveQuestCount})`}
                 component={ExclusiveQuestsTab}
                 path="exclusive-quests"
-                match={match}
               />}
 
               {questCount > 0 && <Tab
                 label={`Quests (${questCount})`}
                 component={QuestsTab}
                 path="quests"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Side/tabs/Areas.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/Areas.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import areaColumns from '../../Area/columns';
@@ -20,8 +21,9 @@ const listAreasForSide = gql`
   ${areaColumns.fragment}
 `;
 
-const AreasTab = ({ match }) => {
-  const { id } = match.params;
+const AreasTab = () => {
+  const params = useParams();
+  const { id } = params;
   return (
     <Collection
       accessor="side.areas"

--- a/packages/spelunker-web/src/components/entities/Side/tabs/ExclusiveQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/ExclusiveQuests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listExclusiveQuestsForSide = gql`
   ${questColumns.fragment}
 `;
 
-const ExclusiveQuestsTab = ({ match }) => {
-  const { id } = match.params;
+const ExclusiveQuestsTab = () => {
+  const params = useParams();
+  const { id } = params;
   return (
     <Collection
       accessor="side.exclusiveQuests"

--- a/packages/spelunker-web/src/components/entities/Side/tabs/Quests.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/Quests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listQuestsForSide = gql`
   ${questColumns.fragment}
 `;
 
-const QuestsTab = ({ match }) => {
-  const { id } = match.params;
+const QuestsTab = () => {
+  const params = useParams();
+  const { id } = params;
   return (
     <Collection
       accessor="side.quests"

--- a/packages/spelunker-web/src/components/entities/Side/tabs/Races.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/Races.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import raceColumns from '../../Race/columns';
@@ -20,8 +21,9 @@ const listRacesForSide = gql`
   ${raceColumns.fragment}
 `;
 
-const RacesTab = ({ match }) => {
-  const { id } = match.params;
+const RacesTab = () => {
+  const params = useParams();
+  const { id } = params;
   return (
     <Collection
       accessor="side.races"

--- a/packages/spelunker-web/src/components/entities/Spell/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import { Box, Query, Tab, TabbedBox, Title } from '../../core';
@@ -28,8 +29,9 @@ const fetchSpell = gql`
   ${SpellReference.fragment}
 `;
 
-const Spell = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const Spell = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Query query={fetchSpell} variables={{ id }}>
       {({ data }) => {
@@ -56,21 +58,18 @@ const Spell = ({ match }) => {
                 label={`Reward from (${rewardFromCount})`}
                 component={RewardFromTab}
                 path="reward-from"
-                match={match}
               />}
 
               {taughtByCount > 0 && <Tab
                 label={`Taught by (${taughtByCount})`}
                 component={TaughtByTab}
                 path="taught-by"
-                match={match}
               />}
 
               {providedForCount > 0 && <Tab
                 label={`Provided for (${providedForCount})`}
                 component={ProvidedForTab}
                 path="provided-for"
-                match={match}
               />}
             </TabbedBox>
           </Title>

--- a/packages/spelunker-web/src/components/entities/Spell/tabs/ProvidedFor.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/tabs/ProvidedFor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listProvidedForForSpell = gql`
   ${questColumns.fragment}
 `;
 
-const ProvidedForTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const ProvidedForTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="spell.providedFor"

--- a/packages/spelunker-web/src/components/entities/Spell/tabs/RewardFrom.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/tabs/RewardFrom.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import questColumns from '../../Quest/columns';
@@ -20,8 +21,9 @@ const listRewardFromForSpell = gql`
   ${questColumns.fragment}
 `;
 
-const RewardFromTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const RewardFromTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="spell.rewardFrom"

--- a/packages/spelunker-web/src/components/entities/Spell/tabs/TaughtBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/tabs/TaughtBy.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import npcColumns from '../../NPC/columns';
@@ -28,8 +29,9 @@ const listTaughtByForSpell = gql`
   ${npcColumns.fragment}
 `;
 
-const TaughtByTab = ({ match }) => {
-  const id = parseInt(match.params.id, 10);
+const TaughtByTab = () => {
+  const params = useParams();
+  const id = parseInt(params.id, 10);
   return (
     <Collection
       accessor="spell.taughtBy"


### PR DESCRIPTION
This PR moves us up to the latest version of React Router, and switches routing from the `withRouter` HOC to hooks.

This PR tweaks the `TabbedBox` component a bit: instead of auto-redirecting to the first tab's path when tabs are mounted but not part of the URL path, we now simply show the first tab by default. This permits multiple `TabbedBox` components to co-exist in a page, and avoids dragging potentially unwanted URL fragments along for the ride when copying and pasting URLs.