### PR TITLE
chore(web): upgrade to apollo client 3

### DIFF
--- a/packages/spelunker-web/package-lock.json
+++ b/packages/spelunker-web/package-lock.json
@@ -4,92 +4,76 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@apollo/react-common": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+    "@apollo/client": {
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.17.tgz",
+      "integrity": "sha512-MDt2rwMX1GqodiVEKJqmDmAz8xr0qJmq5PdWeIt0yDaT4GOkKYWZiWkyfhfv3raTk8PyJvbsNG9q2CqmUrlGfg==",
       "requires": {
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@apollo/react-components": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
-      "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.1",
         "prop-types": "^15.7.2",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.9.0",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "~1.1.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@apollo/react-hoc": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
-      "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "hoist-non-react-statics": "^3.3.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@apollo/react-hooks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@wry/equality": "^0.1.9",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@apollo/react-ssr": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
-      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        "@wry/context": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+          "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@wry/equality": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
+          "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "optimism": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+          "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+          "requires": {
+            "@wry/context": "^0.6.0",
+            "@wry/trie": "^0.3.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+          "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
+        },
+        "ts-invariant": {
+          "version": "0.9.3",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.3.tgz",
+          "integrity": "sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "zen-observable": {
+          "version": "0.8.15",
+          "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+          "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+        },
+        "zen-observable-ts": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+          "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+          "requires": {
+            "@types/zen-observable": "0.8.3",
+            "zen-observable": "0.8.15"
+          }
         }
       }
     },
@@ -254,6 +238,11 @@
         }
       }
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg=="
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -351,7 +340,8 @@
     "@types/node": {
       "version": "16.11.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-      "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+      "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
+      "dev": true
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -625,35 +615,12 @@
       "integrity": "sha512-MOVbCe4lowt6Ffno++f8uxGyA8NS4pV1UiqUShSzA+wbi8G0Vsf9JGM6C1pTXv9jGas9uV+ZzFHHWg8nZsXxQQ==",
       "dev": true
     },
-    "@wry/context": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+    "@wry/trie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
+      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
       "requires": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@wry/equality": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
-      "requires": {
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.3.0"
       }
     },
     "@xtuc/ieee754": {
@@ -766,170 +733,6 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
-      }
-    },
-    "apollo-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-      "requires": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
-      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-client": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
-      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
-      "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
-      },
-      "dependencies": {
-        "apollo-cache": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-          "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-          "requires": {
-            "apollo-utilities": "^1.3.4",
-            "tslib": "^1.10.0"
-          }
-        },
-        "apollo-utilities": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-          "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-          "requires": {
-            "@wry/equality": "^0.1.2",
-            "fast-json-stable-stringify": "^2.0.0",
-            "ts-invariant": "^0.4.0",
-            "tslib": "^1.10.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-link": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
-      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-link-error": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.13.tgz",
-      "integrity": "sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-link-http": {
-      "version": "1.5.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
-      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
-      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "requires": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
     "aproba": {
@@ -5166,7 +4969,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -7684,14 +7488,6 @@
         "is-wsl": "^1.1.0"
       }
     },
-    "optimism": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
-      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
-      "requires": {
-        "@wry/context": "^0.4.0"
-      }
-    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -8356,18 +8152,6 @@
             }
           }
         }
-      }
-    },
-    "react-apollo": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-3.1.5.tgz",
-      "integrity": "sha512-xOxMqxORps+WHrUYbjVHPliviomefOpu5Sh35oO3osuOyPTxvrljdfTLGCggMhcXBsDljtS5Oy4g+ijWg3D4JQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "@apollo/react-hoc": "^3.1.5",
-        "@apollo/react-hooks": "^3.1.5",
-        "@apollo/react-ssr": "^3.1.5"
       }
     },
     "react-dom": {
@@ -9901,11 +9685,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-    },
     "table": {
       "version": "6.7.3",
       "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
@@ -10266,21 +10045,6 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
-    },
-    "ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
-      "requires": {
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
     },
     "tsconfig-paths": {
       "version": "3.11.0",
@@ -11534,27 +11298,6 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      }
-    },
-    "zen-observable": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.8.tgz",
-      "integrity": "sha512-HnhhyNnwTFzS48nihkCZIJGsWGFcYUz+XPDlPK5W84Ifji8SksC6m7sQWOf8zdCGhzQ4tDYuMYGu5B0N1dXTtg=="
-    },
-    "zen-observable-ts": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
-      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-      "requires": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     }
   }

--- a/packages/spelunker-web/package.json
+++ b/packages/spelunker-web/package.json
@@ -18,18 +18,12 @@
     "wowser"
   ],
   "dependencies": {
-    "apollo-cache-inmemory": "^1.6.6",
-    "apollo-client": "^2.6.10",
-    "apollo-link": "^1.2.14",
-    "apollo-link-error": "^1.1.13",
-    "apollo-link-http": "^1.5.17",
+    "@apollo/client": "^3.0.2",
     "classnames": "^2.3.1",
     "graphql": "^14.6.0",
-    "graphql-tag": "^2.10.4",
     "leaflet": "^1.7.1",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
-    "react-apollo": "^3.1.3",
     "react-dom": "^16.14.0",
     "react-leaflet": "^2.8.0",
     "react-router-dom": "^6.0.2"

--- a/packages/spelunker-web/package.json
+++ b/packages/spelunker-web/package.json
@@ -18,7 +18,7 @@
     "wowser"
   ],
   "dependencies": {
-    "@apollo/client": "^3.0.2",
+    "@apollo/client": "^3.4.17",
     "classnames": "^2.3.1",
     "graphql": "^14.6.0",
     "leaflet": "^1.7.1",

--- a/packages/spelunker-web/src/components/Search/ResultsTab.jsx
+++ b/packages/spelunker-web/src/components/Search/ResultsTab.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import accountColumns from '../entities/Account/columns';
 import areaColumns from '../entities/Area/columns';

--- a/packages/spelunker-web/src/components/Search/index.jsx
+++ b/packages/spelunker-web/src/components/Search/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import {
   Box,

--- a/packages/spelunker-web/src/components/Spelunker/graphql-client.js
+++ b/packages/spelunker-web/src/components/Spelunker/graphql-client.js
@@ -1,28 +1,11 @@
-import { ApolloClient } from 'apollo-client';
-import { ApolloLink } from 'apollo-link';
-import {
-  InMemoryCache,
-  IntrospectionFragmentMatcher,
-} from 'apollo-cache-inmemory';
-import { HttpLink } from 'apollo-link-http';
-import { onError } from 'apollo-link-error';
+import { ApolloClient, ApolloLink, HttpLink, InMemoryCache } from '@apollo/client';
+import { onError } from '@apollo/client/link/error';
 
-const fragmentMatcher = new IntrospectionFragmentMatcher({
-  introspectionQueryResultData: {
-    __schema: {
-      types: [{
-        kind: 'UNION',
-        name: 'QuestCategory',
-        possibleTypes: [
-          { name: 'Area' },
-          { name: 'QuestSort' },
-        ],
-      }],
-    },
+const cache = new InMemoryCache({
+  possibleTypes: {
+    QuestCategory: ['Area', 'QuestSort'],
   },
 });
-
-const cache = new InMemoryCache({ fragmentMatcher });
 
 const client = new ApolloClient({
   cache,

--- a/packages/spelunker-web/src/components/Spelunker/index.jsx
+++ b/packages/spelunker-web/src/components/Spelunker/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ApolloProvider } from 'react-apollo';
+import { ApolloProvider } from '@apollo/client';
 import {
   BrowserRouter as Router,
   NavLink,

--- a/packages/spelunker-web/src/components/core/Bounds.js
+++ b/packages/spelunker-web/src/components/core/Bounds.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 const Bounds = () => {};
 

--- a/packages/spelunker-web/src/components/core/Query/index.jsx
+++ b/packages/spelunker-web/src/components/core/Query/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Query as ApolloQuery } from 'react-apollo';
+import { Query as ApolloQuery } from '@apollo/client/react/components';
 
 import { Error, ErrorBoundary } from '../';
 

--- a/packages/spelunker-web/src/components/entities/Account/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Account/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Account/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/Account/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 const AccountReference = ({ account }) => (

--- a/packages/spelunker-web/src/components/entities/Account/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Account/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import AccountReference from '../Reference';
 import { IDColumn, PlaceholderColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Account/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Account/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Query, Tab, TabbedBox, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Account/tabs/Characters.jsx
+++ b/packages/spelunker-web/src/components/entities/Account/tabs/Characters.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Collection, Table } from '../../../core';
 import characterColumns from '../../Character/columns';

--- a/packages/spelunker-web/src/components/entities/Area/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Area/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Area/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/Area/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import SideReference from '../Side/Reference';

--- a/packages/spelunker-web/src/components/entities/Area/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Area/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import AreaReference from '../Reference';
 import { IDColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Area/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Area/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import {
   Bounds,

--- a/packages/spelunker-web/src/components/entities/Area/tabs/Quests.jsx
+++ b/packages/spelunker-web/src/components/entities/Area/tabs/Quests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Area/tabs/Subareas.jsx
+++ b/packages/spelunker-web/src/components/entities/Area/tabs/Subareas.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import areaColumns from '../columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Character/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Character/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import ClassIcon from '../Class/Icon';

--- a/packages/spelunker-web/src/components/entities/Character/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import CharacterReference from '../Reference';
 import ClassReference from '../../Class/Reference';

--- a/packages/spelunker-web/src/components/entities/Character/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import AccountReference from '../Account/Reference';
 import LocationSelector from '../Location/Selector';

--- a/packages/spelunker-web/src/components/entities/Character/tabs/CompletedQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/CompletedQuests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Character/tabs/CurrentQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/CurrentQuests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Column, Table, prefixAccessors } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Character/tabs/Inventory.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/Inventory.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import itemColumns from '../../Item/columns';
 import { Collection, Column, Table, prefixAccessors } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Character/tabs/Reputation.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/Reputation.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import factionColumns from '../../Faction/columns';
 import { Collection, Column, Table, prefixAccessors } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Character/tabs/UncompletedQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Character/tabs/UncompletedQuests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Class/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Class/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import ClassIcon from './Icon';

--- a/packages/spelunker-web/src/components/entities/Class/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import ClassReference from '../Reference';
 import { IDColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Class/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Query, Tab, TabbedBox, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Class/tabs/ExclusiveQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/tabs/ExclusiveQuests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Class/tabs/Quests.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/tabs/Quests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Class/tabs/Races.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/tabs/Races.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import raceColumns from '../../Race/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Faction/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Faction/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Faction/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/Faction/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 const FactionReference = ({ faction }) => (

--- a/packages/spelunker-web/src/components/entities/Faction/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Faction/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import FactionReference from '../Reference';
 import { IDColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Faction/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Faction/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Query, List, ListItem, Tab, TabbedBox, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Faction/tabs/ObjectiveOf.jsx
+++ b/packages/spelunker-web/src/components/entities/Faction/tabs/ObjectiveOf.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Faction/tabs/Subfactions.jsx
+++ b/packages/spelunker-web/src/components/entities/Faction/tabs/Subfactions.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import factionColumns from '../columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/GameObject/List.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/GameObject/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import QuestgiverIcon from '../../images/QuestgiverIcon';

--- a/packages/spelunker-web/src/components/entities/GameObject/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import GameObjectReference from '../Reference';
 import { Column, IDColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/GameObject/index.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import LocationSelector from '../Location/Selector';
 import {

--- a/packages/spelunker-web/src/components/entities/GameObject/tabs/Contains.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/tabs/Contains.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import itemColumns from '../../Item/columns';
 import { ChanceColumn, Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/GameObject/tabs/Ends.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/tabs/Ends.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/GameObject/tabs/ObjectiveOf.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/tabs/ObjectiveOf.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/GameObject/tabs/Starts.jsx
+++ b/packages/spelunker-web/src/components/entities/GameObject/tabs/Starts.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Item/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Item/Reference/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/Reference/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import GameIcon from '../../../images/GameIcon';

--- a/packages/spelunker-web/src/components/entities/Item/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import ItemReference from '../Reference';
 import { IDColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Item/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import Currency from '../../formatters/Currency';
 import ItemSetReference from '../ItemSet/Reference';

--- a/packages/spelunker-web/src/components/entities/Item/tabs/ContainedIn.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/ContainedIn.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import itemColumns from '../columns';
 import {

--- a/packages/spelunker-web/src/components/entities/Item/tabs/ContainedInObject.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/ContainedInObject.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import gameObjectColumns from '../../GameObject/columns';
 import {

--- a/packages/spelunker-web/src/components/entities/Item/tabs/Contains.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/Contains.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import itemColumns from '../columns';
 import {

--- a/packages/spelunker-web/src/components/entities/Item/tabs/DroppedBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/DroppedBy.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import npcColumns from '../../NPC/columns';
 import {

--- a/packages/spelunker-web/src/components/entities/Item/tabs/ObjectiveOf.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/ObjectiveOf.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Item/tabs/ProvidedFor.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/ProvidedFor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Item/tabs/RewardFrom.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/RewardFrom.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Item/tabs/SoldBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/SoldBy.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import npcColumns from '../../NPC/columns';
 import {

--- a/packages/spelunker-web/src/components/entities/Item/tabs/Starts.jsx
+++ b/packages/spelunker-web/src/components/entities/Item/tabs/Starts.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/ItemSet/List.jsx
+++ b/packages/spelunker-web/src/components/entities/ItemSet/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/ItemSet/Reference/index.jsx
+++ b/packages/spelunker-web/src/components/entities/ItemSet/Reference/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import styles from '../../Item/Reference/index.styl';

--- a/packages/spelunker-web/src/components/entities/ItemSet/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/ItemSet/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import ItemSetReference from '../Reference';
 import { IDColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/ItemSet/index.jsx
+++ b/packages/spelunker-web/src/components/entities/ItemSet/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import ItemReference from '../Item/Reference';
 import { Box, List, ListItem, Query, Title } from '../../core';

--- a/packages/spelunker-web/src/components/entities/Map/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Map/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 const MapReference = ({ map }) => (

--- a/packages/spelunker-web/src/components/entities/Map/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import MapReference from '../Reference';
 import { IDColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Map/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Bounds, Box, GameMap, Query, Tab, TabbedBox, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Map/tabs/Areas.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/tabs/Areas.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Collection, Table } from '../../../core';
 import areaColumns from '../../Area/columns';

--- a/packages/spelunker-web/src/components/entities/Map/tabs/GameObjectSpawns.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/tabs/GameObjectSpawns.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import GameObjectReference from '../../GameObject/Reference';
 import { Collection, Column, IDColumn, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Map/tabs/NPCSpawns.jsx
+++ b/packages/spelunker-web/src/components/entities/Map/tabs/NPCSpawns.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import NPCReference from '../../NPC/Reference';
 import { Collection, Column, IDColumn, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/NPC/List.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/NPC/Reference/index.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/Reference/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import QuestgiverIcon from '../../../images/QuestgiverIcon';

--- a/packages/spelunker-web/src/components/entities/NPC/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import NPCReference from '../Reference';
 import { IDColumn, PlaceholderColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/NPC/index.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import LocationSelector from '../Location/Selector';
 import {

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Drops.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Drops.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import itemColumns from '../../Item/columns';
 import {

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Ends.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Ends.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/ObjectiveOf.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/ObjectiveOf.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Sells.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Sells.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import itemColumns from '../../Item/columns';
 import {

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Starts.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Starts.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/NPC/tabs/Teaches.jsx
+++ b/packages/spelunker-web/src/components/entities/NPC/tabs/Teaches.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import spellColumns from '../../Spell/columns';
 import {

--- a/packages/spelunker-web/src/components/entities/Quest/Category.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/Category.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import AreaReference from '../Area/Reference';
 

--- a/packages/spelunker-web/src/components/entities/Quest/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Quest/Reference/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/Reference/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import SideReference from '../../Side/Reference';

--- a/packages/spelunker-web/src/components/entities/Quest/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import ClassReference from '../../Class/Reference';
 import QuestCategory from '../Category';

--- a/packages/spelunker-web/src/components/entities/Quest/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import ClassReference from '../Class/Reference';
 import Currency from '../../formatters/Currency';

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/EndedBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/EndedBy.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import npcColumns from '../../NPC/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/EndedByObject.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/EndedByObject.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import gameObjectColumns from '../../GameObject/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/StartedBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/StartedBy.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import npcColumns from '../../NPC/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/StartedByItem.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/StartedByItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import itemColumns from '../../Item/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Quest/tabs/StartedByObject.jsx
+++ b/packages/spelunker-web/src/components/entities/Quest/tabs/StartedByObject.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import gameObjectColumns from '../../GameObject/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Race/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Race/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import RaceIcon from './Icon';

--- a/packages/spelunker-web/src/components/entities/Race/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import RaceReference from '../Reference';
 import SideReference from '../../Side/Reference';

--- a/packages/spelunker-web/src/components/entities/Race/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import SideReference from '../Side/Reference';
 import { Box, Query, Tab, TabbedBox, Title } from '../../core';

--- a/packages/spelunker-web/src/components/entities/Race/tabs/Classes.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/tabs/Classes.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import classColumns from '../../Class/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Race/tabs/ExclusiveQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/tabs/ExclusiveQuests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Race/tabs/Quests.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/tabs/Quests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Side/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import SideIcon from './Icon';

--- a/packages/spelunker-web/src/components/entities/Side/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import SideReference from '../Reference';
 import { IDColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Side/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Query, Tab, TabbedBox, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Side/tabs/Areas.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/Areas.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import areaColumns from '../../Area/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Side/tabs/ExclusiveQuests.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/ExclusiveQuests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Side/tabs/Quests.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/Quests.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Side/tabs/Races.jsx
+++ b/packages/spelunker-web/src/components/entities/Side/tabs/Races.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import raceColumns from '../../Race/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Spell/List.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/List.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Collection, Table, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Spell/Reference.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/Reference.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import GameIcon from '../../images/GameIcon';

--- a/packages/spelunker-web/src/components/entities/Spell/columns/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/columns/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import SpellReference from '../Reference';
 import { IDColumn } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Spell/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import { Box, Query, Tab, TabbedBox, Title } from '../../core';
 

--- a/packages/spelunker-web/src/components/entities/Spell/tabs/ProvidedFor.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/tabs/ProvidedFor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Spell/tabs/RewardFrom.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/tabs/RewardFrom.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import questColumns from '../../Quest/columns';
 import { Collection, Table } from '../../../core';

--- a/packages/spelunker-web/src/components/entities/Spell/tabs/TaughtBy.jsx
+++ b/packages/spelunker-web/src/components/entities/Spell/tabs/TaughtBy.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 import npcColumns from '../../NPC/columns';
 import {


### PR DESCRIPTION
This one isn't quite ready yet: occasionally, when navigating, I get warnings like this:

> Cache data may be lost when replacing the classes field of a Quest object.
>
> To address this problem (which is not a bug in Apollo Client), either ensure all objects of type ClassCollection have an ID or a custom merge function, or define a custom merge function for the Quest.classes field, so InMemoryCache can safely merge these objects:
>
>  existing: {"__typename":"ClassCollection","totalCount":0,"results":[]}
>  incoming: {"__typename":"ClassCollection","results":[]}
>
> For more information about these options, please refer to the documentation:
>
>  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
>  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects