### PR TITLE
chore(web): update graphql dependency

### DIFF
--- a/packages/spelunker-web/package-lock.json
+++ b/packages/spelunker-web/package-lock.json
@@ -5417,12 +5417,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
-      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
-      "requires": {
-        "iterall": "^1.2.2"
-      }
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A=="
     },
     "graphql-tag": {
       "version": "2.12.6",
@@ -6330,11 +6327,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/packages/spelunker-web/package.json
+++ b/packages/spelunker-web/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.17",
     "classnames": "^2.3.1",
-    "graphql": "^14.6.0",
+    "graphql": "^15.7.2",
     "leaflet": "^1.7.1",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",


### PR DESCRIPTION
This PR updates our `spelunker-web` GraphQL dependency from 14.x to the latest 15.x release. Apollo Client is compatible with both 14.x and 15.x.