### PR TITLE
lint(web): allow usage of console.error in graphql client

### DIFF
--- a/packages/spelunker-web/src/components/Spelunker/graphql-client.js
+++ b/packages/spelunker-web/src/components/Spelunker/graphql-client.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 import { ApolloClient, ApolloLink, HttpLink, InMemoryCache } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
 


### PR DESCRIPTION
Allows usage of `console` in `graphql-client.js`, preventing the following messages from showing up in future PRs:

<img width="642" alt="Screenshot 2021-11-19 at 21 20 55" src="https://user-images.githubusercontent.com/378235/142690393-33f5f2bc-b9f1-4d50-aa4d-bb2fa96e557a.png">