### PR TITLE
chore(web): exclude ie_mob from babel targets

### DIFF
--- a/packages/spelunker-web/babel.config.json
+++ b/packages/spelunker-web/babel.config.json
@@ -6,6 +6,7 @@
         "browsers": [
           "last 2 versions",
           "not ie 1-11",
+          "not ie_mob 1-11",
           "not android 1-62"
         ]
       },


### PR DESCRIPTION
We were still allowing `ie_mob` in, which ended up turning on a bunch of unnecessary transforms.

*Before*
```
Using plugins:
  proposal-class-static-block { ie, ios, node < 16.11, safari, samsung }
  proposal-private-property-in-object { ie, ios < 15, node < 16.9, samsung }
  proposal-class-properties { ie, ios < 15, node < 14.6 }
  proposal-private-methods { ie, ios < 15, node < 14.6 }
  proposal-numeric-separator { ie }
  proposal-logical-assignment-operators { ie, node < 15 }
  proposal-nullish-coalescing-operator { ie, node < 14 }
  proposal-optional-chaining { ie, node < 16.9, samsung }
  proposal-json-strings { ie }
  proposal-optional-catch-binding { ie }
  transform-parameters { ie, ios, safari }
  proposal-async-generator-functions { ie }
  proposal-object-rest-spread { ie }
  transform-dotall-regex { ie }
  proposal-unicode-property-regex { ie }
  transform-named-capturing-groups-regex { ie }
  transform-async-to-generator { ie }
  transform-exponentiation-operator { ie }
  transform-template-literals { ie }
  transform-literals { ie }
  transform-function-name { ie }
  transform-arrow-functions { ie }
  transform-block-scoped-functions { ie < 11 }
  transform-classes { ie }
  transform-object-super { ie }
  transform-shorthand-properties { ie }
  transform-duplicate-keys { ie }
  transform-computed-properties { ie }
  transform-for-of { ie }
  transform-sticky-regex { ie }
  transform-unicode-escapes { ie }
  transform-unicode-regex { ie }
  transform-spread { ie }
  transform-destructuring { ie }
  transform-block-scoping { ie }
  transform-typeof-symbol { ie }
  transform-new-target { ie }
  transform-regenerator { ie }
  proposal-export-namespace-from { ie, ios, node < 13.2, safari }
  syntax-dynamic-import
  syntax-top-level-await
```

*After*
```
Using plugins:
  proposal-class-static-block { ios, node < 16.11, safari, samsung }
  proposal-private-property-in-object { ios < 15, node < 16.9, samsung }
  proposal-class-properties { ios < 15, node < 14.6 }
  proposal-private-methods { ios < 15, node < 14.6 }
  syntax-numeric-separator
  proposal-logical-assignment-operators { node < 15 }
  proposal-nullish-coalescing-operator { node < 14 }
  proposal-optional-chaining { node < 16.9, samsung }
  syntax-json-strings
  syntax-optional-catch-binding
  transform-parameters { ios, safari }
  syntax-async-generators
  syntax-object-rest-spread
  proposal-export-namespace-from { ios, node < 13.2, safari }
  syntax-dynamic-import
  syntax-top-level-await
```