### PR TITLE
chore(web): ignore .js.map files in the build output directory

### DIFF
--- a/packages/spelunker-web/.gitignore
+++ b/packages/spelunker-web/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /public/*.html
 /public/*.js
+/public/*.js.map


### PR DESCRIPTION
Webpack produces `.js.map` files when running builds. This PR keeps us from inadvertently putting them in source control.