### PR TITLE
chore(web): enable es2020 support in eslint

### DIFF
--- a/packages/spelunker-web/.eslintrc
+++ b/packages/spelunker-web/.eslintrc
@@ -21,7 +21,10 @@
   },
   "env": {
     "browser": true,
-    "es6": true,
+    "es2020": true,
     "node": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
   }
 }


### PR DESCRIPTION
This PR enables support for ES2020 language features (like nullish coalescing) for `spelunker-web` in the ESLint parser. Babel already supports these features.