### PR TITLE
feat(web): add type policy generator for CollectionType

### DIFF
--- a/packages/spelunker-web/src/components/Spelunker/graphql-client.js
+++ b/packages/spelunker-web/src/components/Spelunker/graphql-client.js
@@ -18,7 +18,7 @@ const cache = new InMemoryCache({
     Quest: {
       fields: {
         classes: collectionPolicy(),
-        races: collectionPolicy({ keyArgs: ['exclusive'] }),
+        races: collectionPolicy('exclusive'),
       },
     },
   },

--- a/packages/spelunker-web/src/components/Spelunker/graphql-client.js
+++ b/packages/spelunker-web/src/components/Spelunker/graphql-client.js
@@ -13,6 +13,7 @@ const cache = new InMemoryCache({
     Area: {
       fields: {
         quests: collectionPolicy(),
+        subareas: collectionPolicy(),
       },
     },
     Quest: {

--- a/packages/spelunker-web/src/components/Spelunker/graphql-client.js
+++ b/packages/spelunker-web/src/components/Spelunker/graphql-client.js
@@ -3,9 +3,24 @@
 import { ApolloClient, ApolloLink, HttpLink, InMemoryCache } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
 
+import { collectionPolicy } from '../../utils/policies';
+
 const cache = new InMemoryCache({
   possibleTypes: {
     QuestCategory: ['Area', 'QuestSort'],
+  },
+  typePolicies: {
+    Area: {
+      fields: {
+        quests: collectionPolicy(),
+      },
+    },
+    Quest: {
+      fields: {
+        classes: collectionPolicy(),
+        races: collectionPolicy({ keyArgs: ['exclusive'] }),
+      },
+    },
   },
 });
 

--- a/packages/spelunker-web/src/utils/graphql.js
+++ b/packages/spelunker-web/src/utils/graphql.js
@@ -1,0 +1,8 @@
+/* eslint-disable import/prefer-default-export */
+
+const getSelectedFields = field => (field?.selectionSet?.selections ?? [])
+  .map(selection => selection.name.value);
+
+export {
+  getSelectedFields,
+};

--- a/packages/spelunker-web/src/utils/policies/collection.js
+++ b/packages/spelunker-web/src/utils/policies/collection.js
@@ -3,7 +3,7 @@ import { getSelectedFields } from '../graphql';
 const DEFAULT_OFFSET = 0;
 const DEFAULT_LIMIT = 25;
 
-const getCollectionResults = (args, collection) => {
+const getCollectionResults = (collection, args) => {
   // Use total if known, otherwise assume results match total
   const total = collection.totalCount ?? collection.results.length;
 
@@ -80,7 +80,7 @@ const read = (existing, { args, field }) => {
       return undefined;
     }
 
-    response.results = getCollectionResults(args, existing);
+    response.results = getCollectionResults(existing, args);
 
     // Cached collection contains incomplete results
     if (response.results.includes(undefined)) {

--- a/packages/spelunker-web/src/utils/policies/collection.js
+++ b/packages/spelunker-web/src/utils/policies/collection.js
@@ -1,14 +1,14 @@
 import { getSelectedFields } from '../graphql';
 
+const DEFAULT_OFFSET = 0;
+const DEFAULT_LIMIT = 25;
+
 const getCollectionResults = (args, collection) => {
   // Use total if known, otherwise assume results match total
   const total = collection.totalCount ?? collection.results.length;
 
-  const defaultOffset = 0;
-  const offset = args?.offset ?? defaultOffset;
-
-  const defaultLimit = 25;
-  const limit = Math.min(args?.limit ?? defaultLimit, total - offset);
+  const offset = args?.offset ?? DEFAULT_OFFSET;
+  const limit = Math.min(args?.limit ?? DEFAULT_LIMIT, total - offset);
 
   const results = collection.results.slice(offset, offset + limit);
 
@@ -39,8 +39,7 @@ const merge = (existing, incoming, { args }) => {
       ? existing.results.slice(0)
       : [];
 
-    const defaultOffset = 0;
-    const offset = args?.offset ?? defaultOffset;
+    const offset = args?.offset ?? DEFAULT_OFFSET;
 
     for (let i = 0; i < incoming.results.length; ++i) {
       mergedResults[offset + i] = incoming.results[i];

--- a/packages/spelunker-web/src/utils/policies/collection.js
+++ b/packages/spelunker-web/src/utils/policies/collection.js
@@ -4,17 +4,18 @@ const DEFAULT_OFFSET = 0;
 const DEFAULT_LIMIT = 25;
 
 const getCollectionResults = (collection, args) => {
-  // Use total if known, otherwise assume results match total
-  const total = collection.totalCount ?? collection.results.length;
-
   const offset = args?.offset ?? DEFAULT_OFFSET;
-  const limit = Math.min(args?.limit ?? DEFAULT_LIMIT, total - offset);
+  const limit = args?.limit ?? DEFAULT_LIMIT;
 
-  const results = collection.results.slice(offset, offset + limit);
+  // Clamp limit by total
+  const total = collection.totalCount ?? offset + limit;
+  const clampedLimit = Math.min(limit, total - offset);
 
-  // Stretch array to permissable limit
-  if (results.length < limit) {
-    results.push(...new Array(limit - results.length));
+  const results = collection.results.slice(offset, offset + clampedLimit);
+
+  // Stretch array to clamped limit
+  if (results.length < clampedLimit) {
+    results.push(...new Array(clampedLimit - results.length));
   }
 
   return results;

--- a/packages/spelunker-web/src/utils/policies/collection.js
+++ b/packages/spelunker-web/src/utils/policies/collection.js
@@ -20,75 +20,77 @@ const getCollectionResults = (args, collection) => {
   return results;
 };
 
-const collectionPolicy = ({ keyArgs = false } = {}) => ({
-  keyArgs,
+const merge = (existing, incoming, { args }) => {
+  // If nothing was cached, no merge needs to happen (yet)
+  if (!existing) {
+    return incoming;
+  }
 
-  merge: (existing, incoming, { args }) => {
-    // If nothing was cached, no merge needs to happen (yet)
-    if (!existing) {
-      return incoming;
+  const merged = { ...existing };
+
+  // Merge totalCount if present
+  if (incoming.totalCount !== undefined) {
+    merged.totalCount = incoming.totalCount;
+  }
+
+  // Merge results if present
+  if (incoming.results !== undefined) {
+    const mergedResults = Array.isArray(existing.results)
+      ? existing.results.slice(0)
+      : [];
+
+    const defaultOffset = 0;
+    const offset = args?.offset ?? defaultOffset;
+
+    for (let i = 0; i < incoming.results.length; ++i) {
+      mergedResults[offset + i] = incoming.results[i];
     }
 
-    const merged = { ...existing };
+    merged.results = mergedResults;
+  }
 
-    // Merge totalCount if present
-    if (incoming.totalCount !== undefined) {
-      merged.totalCount = incoming.totalCount;
-    }
+  return merged;
+};
 
-    // Merge results if present
-    if (incoming.results !== undefined) {
-      const mergedResults = Array.isArray(existing.results)
-        ? existing.results.slice(0)
-        : [];
+const read = (existing, { args, field }) => {
+  // Nothing is cached
+  if (!existing) {
+    return undefined;
+  }
 
-      const defaultOffset = 0;
-      const offset = args?.offset ?? defaultOffset;
+  const selectedFields = getSelectedFields(field);
+  const response = { ...existing };
 
-      for (let i = 0; i < incoming.results.length; ++i) {
-        mergedResults[offset + i] = incoming.results[i];
-      }
-
-      merged.results = mergedResults;
-    }
-
-    return merged;
-  },
-
-  read: (existing, { args, field }) => {
-    // Nothing is cached
-    if (!existing) {
+  if (selectedFields.includes('totalCount')) {
+    // totalCount field is selected, but missing from cache
+    if (existing.totalCount === undefined) {
       return undefined;
     }
 
-    const selectedFields = getSelectedFields(field);
-    const response = { ...existing };
+    response.totalCount = existing.totalCount;
+  }
 
-    if (selectedFields.includes('totalCount')) {
-      // totalCount field is selected, but missing from cache
-      if (existing.totalCount === undefined) {
-        return undefined;
-      }
-
-      response.totalCount = existing.totalCount;
+  if (selectedFields.includes('results')) {
+    // results field is selected, but missing from cache
+    if (existing.results === undefined) {
+      return undefined;
     }
 
-    if (selectedFields.includes('results')) {
-      // results field is selected, but missing from cache
-      if (existing.results === undefined) {
-        return undefined;
-      }
+    response.results = getCollectionResults(args, existing);
 
-      response.results = getCollectionResults(args, existing);
-
-      // Cached collection contains incomplete results
-      if (response.results.includes(undefined)) {
-        return undefined;
-      }
+    // Cached collection contains incomplete results
+    if (response.results.includes(undefined)) {
+      return undefined;
     }
+  }
 
-    return response;
-  },
+  return response;
+};
+
+const collectionPolicy = (...keyArgs) => ({
+  keyArgs: keyArgs.length === 0 ? false : keyArgs,
+  merge,
+  read,
 });
 
 export default collectionPolicy;

--- a/packages/spelunker-web/src/utils/policies/collection.js
+++ b/packages/spelunker-web/src/utils/policies/collection.js
@@ -1,0 +1,94 @@
+import { getSelectedFields } from '../graphql';
+
+const getCollectionResults = (args, collection) => {
+  // Use total if known, otherwise assume results match total
+  const total = collection.totalCount ?? collection.results.length;
+
+  const defaultOffset = 0;
+  const offset = args?.offset ?? defaultOffset;
+
+  const defaultLimit = 25;
+  const limit = Math.min(args?.limit ?? defaultLimit, total - offset);
+
+  const results = collection.results.slice(offset, offset + limit);
+
+  // Stretch array to permissable limit
+  if (results.length < limit) {
+    results.push(...new Array(limit - results.length));
+  }
+
+  return results;
+};
+
+const collectionPolicy = ({ keyArgs = false } = {}) => ({
+  keyArgs,
+
+  merge: (existing, incoming, { args }) => {
+    // If nothing was cached, no merge needs to happen (yet)
+    if (!existing) {
+      return incoming;
+    }
+
+    const merged = { ...existing };
+
+    // Merge totalCount if present
+    if (incoming.totalCount !== undefined) {
+      merged.totalCount = incoming.totalCount;
+    }
+
+    // Merge results if present
+    if (incoming.results !== undefined) {
+      const mergedResults = Array.isArray(existing.results)
+        ? existing.results.slice(0)
+        : [];
+
+      const defaultOffset = 0;
+      const offset = args?.offset ?? defaultOffset;
+
+      for (let i = 0; i < incoming.results.length; ++i) {
+        mergedResults[offset + i] = incoming.results[i];
+      }
+
+      merged.results = mergedResults;
+    }
+
+    return merged;
+  },
+
+  read: (existing, { args, field }) => {
+    // Nothing is cached
+    if (!existing) {
+      return undefined;
+    }
+
+    const selectedFields = getSelectedFields(field);
+    const response = { ...existing };
+
+    if (selectedFields.includes('totalCount')) {
+      // totalCount field is selected, but missing from cache
+      if (existing.totalCount === undefined) {
+        return undefined;
+      }
+
+      response.totalCount = existing.totalCount;
+    }
+
+    if (selectedFields.includes('results')) {
+      // results field is selected, but missing from cache
+      if (existing.results === undefined) {
+        return undefined;
+      }
+
+      response.results = getCollectionResults(args, existing);
+
+      // Cached collection contains incomplete results
+      if (response.results.includes(undefined)) {
+        return undefined;
+      }
+    }
+
+    return response;
+  },
+});
+
+export default collectionPolicy;

--- a/packages/spelunker-web/src/utils/policies/index.js
+++ b/packages/spelunker-web/src/utils/policies/index.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+
+import collectionPolicy from './collection';
+
+export {
+  collectionPolicy,
+};


### PR DESCRIPTION
This PR introduces a special type policy generator for our `CollectionType`. This permits clean merges for data, while still allowing lazy loads and arbitrary offset windowing.