### PR TITLE
feat(web): enable persisted queries

### DIFF
--- a/packages/spelunker-web/package-lock.json
+++ b/packages/spelunker-web/package-lock.json
@@ -2911,6 +2911,11 @@
         "which": "^2.0.1"
       }
     },
+    "crypto-hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-2.0.0.tgz",
+      "integrity": "sha512-uua9EnThQk7vkDCm6Ltab/7QR6XzPiV2bSdLdvbwdZKb4lot94kHkherQt6uw1hNntXjDA7lNHj2vFm1JaYt0g=="
+    },
     "css": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",

--- a/packages/spelunker-web/package.json
+++ b/packages/spelunker-web/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.17",
     "classnames": "^2.3.1",
+    "crypto-hash": "^2.0.0",
     "graphql": "^15.7.2",
     "leaflet": "^1.7.1",
     "prop-types": "^15.7.2",

--- a/packages/spelunker-web/src/components/Spelunker/graphql-client.js
+++ b/packages/spelunker-web/src/components/Spelunker/graphql-client.js
@@ -2,6 +2,8 @@
 
 import { ApolloClient, ApolloLink, HttpLink, InMemoryCache } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
+import { createPersistedQueryLink } from '@apollo/client/link/persisted-queries';
+import { sha256 } from 'crypto-hash';
 
 import { collectionPolicy } from '../../utils/policies';
 
@@ -40,6 +42,7 @@ const client = new ApolloClient({
         console.error(networkError);
       }
     }),
+    createPersistedQueryLink({ sha256, useGETForHashedQueries: true }),
     new HttpLink({
       uri: process.env.API_URI,
       credentials: 'same-origin',


### PR DESCRIPTION
This PR kicks on automatic persisted queries for our Apollo client in `spelunker-web`. It also enables the persisted queries to operate via `GET` requests, giving us options for CDN caching of responses.