### PR TITLE
chore(web): separate build outputs

### DIFF
--- a/packages/spelunker-web/.gitignore
+++ b/packages/spelunker-web/.gitignore
@@ -1,4 +1,3 @@
 /node_modules
 /public/*.html
-/public/*.js
-/public/*.js.map
+/public/static

--- a/packages/spelunker-web/package-lock.json
+++ b/packages/spelunker-web/package-lock.json
@@ -7869,50 +7869,6 @@
         }
       }
     },
-    "url-loader": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
-      "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "mime-types": "^2.1.27",
-        "schema-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        }
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/packages/spelunker-web/package.json
+++ b/packages/spelunker-web/package.json
@@ -46,7 +46,6 @@
     "style-loader": "^3.3.1",
     "stylus": "^0.54.8",
     "stylus-loader": "^6.2.0",
-    "url-loader": "^4.1.1",
     "webpack": "^5.64.2",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.5.0"

--- a/packages/spelunker-web/webpack.config.js
+++ b/packages/spelunker-web/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.png$/,
+        test: /\.(gif|jpe?g|png)$/,
         type: 'asset',
         parser: {
           dataUrlCondition: {

--- a/packages/spelunker-web/webpack.config.js
+++ b/packages/spelunker-web/webpack.config.js
@@ -6,7 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 module.exports = {
   entry: './src/bootstrap.jsx',
   output: {
-    filename: 'spelunker-[contenthash].js',
+    filename: 'static/js/[name]-[contenthash].js',
     path: path.resolve(__dirname, 'public'),
     publicPath: '/',
   },
@@ -27,14 +27,15 @@ module.exports = {
     rules: [
       {
         test: /\.png$/,
-        use: [
-          {
-            loader: 'url-loader',
-            options: {
-              limit: 8192,
-            },
+        type: 'asset',
+        parser: {
+          dataUrlCondition: {
+            maxSize: 8 * 1024,
           },
-        ],
+        },
+        generator: {
+          filename: 'static/img/[name]-[contenthash][ext][query]',
+        },
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
This PR moves static webpack build outputs from `/public` to `/public/static`, split by `js` and `img`. It also drops `url-loader` in favor of webpack 5's built in asset modules.

This PR keeps `html-webpack-plugin`'s `index.html` output in the root of `/public`.

These changes will make it simple for us to define long-term caching policies for our content hashed build outputs, while keeping the entrypoint `index.html` uncached.