### PR TITLE
feat: normalize pipeline paths

### DIFF
--- a/packages/spelunker-api/src/lib/pipeline/index.mjs
+++ b/packages/spelunker-api/src/lib/pipeline/index.mjs
@@ -7,10 +7,12 @@ import mpq from '../mpq/index.mjs';
 
 const { PNG } = pngjs;
 
+const toMPQPath = path => path.replace(/\//g, '\\');
+
 const pipeline = express();
 
 pipeline.param('resource', (req, res, next, path) => {
-  req.resource = mpq.files.get(path);
+  req.resource = mpq.files.get(toMPQPath(path));
   if (req.resource) {
     next();
 
@@ -30,7 +32,7 @@ pipeline.get('/minimap/:mapName/:tx/:ty.blp.png', (req, res) => {
   const index = `${mapName}\\map${tx}_${ty}`;
   const tile = minimapTiles[index];
   if (tile) {
-    res.redirect(`${req.baseUrl}/textures\\Minimap\\${tile}.png`);
+    res.redirect(`${req.baseUrl}/textures/minimap/${tile}.png`);
   } else {
     res.sendStatus(404);
   }

--- a/packages/spelunker-web/src/components/entities/Class/Icon/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/Icon/index.jsx
@@ -10,7 +10,7 @@ const ClassIcon = ({ class: klass, size }) => {
   const className = classNames(styles.icon, styles[size], style);
   return (
     <GameIcon
-      file="Interface\GLUES\CHARACTERCREATE\UI-CHARACTERCREATE-CLASSES.BLP"
+      file="interface/glues/charactercreate/ui-charactercreate-classes.blp"
       className={className}
       asBackground
     />

--- a/packages/spelunker-web/src/components/entities/Class/Icon/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Class/Icon/index.jsx
@@ -10,7 +10,7 @@ const ClassIcon = ({ class: klass, size }) => {
   const className = classNames(styles.icon, styles[size], style);
   return (
     <GameIcon
-      file="interface/glues/charactercreate/ui-charactercreate-classes.blp"
+      file="Interface/GLUES/CHARACTERCREATE/UI-CHARACTERCREATE-CLASSES.BLP"
       className={className}
       asBackground
     />

--- a/packages/spelunker-web/src/components/entities/Race/Icon/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/Icon/index.jsx
@@ -15,7 +15,7 @@ const RaceIcon = ({ race, gender, size }) => {
   const className = classNames(styles.icon, styles[size], style);
   return (
     <GameIcon
-      file="interface/glues/charactercreate/ui-charactercreate-races.blp"
+      file="Interface/GLUES/CHARACTERCREATE/UI-CharacterCreate-Races.BLP"
       className={className}
       asBackground
     />

--- a/packages/spelunker-web/src/components/entities/Race/Icon/index.jsx
+++ b/packages/spelunker-web/src/components/entities/Race/Icon/index.jsx
@@ -15,7 +15,7 @@ const RaceIcon = ({ race, gender, size }) => {
   const className = classNames(styles.icon, styles[size], style);
   return (
     <GameIcon
-      file="Interface\GLUES\CHARACTERCREATE\UI-CharacterCreate-Races.BLP"
+      file="interface/glues/charactercreate/ui-charactercreate-races.blp"
       className={className}
       asBackground
     />

--- a/packages/spelunker-web/src/components/formatters/Currency/index.jsx
+++ b/packages/spelunker-web/src/components/formatters/Currency/index.jsx
@@ -17,21 +17,21 @@ const Currency = ({ value }) => {
       {gold ? (
         <span>
           {number(gold)}&nbsp;
-          <GameIcon file="interface/moneyframe/ui-goldicon.blp" />
+          <GameIcon file="Interface/MoneyFrame/UI-GoldIcon.blp" />
         </span>
       ) : null}
 
       {silver ? (
         <span>
           {silver}&nbsp;
-          <GameIcon file="interface/moneyframe/ui-silvericon.blp" />
+          <GameIcon file="Interface/MoneyFrame/UI-SilverIcon.blp" />
         </span>
       ) : null}
 
       {copper ? (
         <span>
           {copper}&nbsp;
-          <GameIcon file="interface/moneyframe/ui-coppericon.blp" />
+          <GameIcon file="Interface/MoneyFrame/UI-CopperIcon.blp" />
         </span>
       ) : null}
     </span>

--- a/packages/spelunker-web/src/components/formatters/Currency/index.jsx
+++ b/packages/spelunker-web/src/components/formatters/Currency/index.jsx
@@ -17,21 +17,21 @@ const Currency = ({ value }) => {
       {gold ? (
         <span>
           {number(gold)}&nbsp;
-          <GameIcon file="Interface\MoneyFrame\UI-GoldIcon.blp" />
+          <GameIcon file="interface/moneyframe/ui-goldicon.blp" />
         </span>
       ) : null}
 
       {silver ? (
         <span>
           {silver}&nbsp;
-          <GameIcon file="Interface\MoneyFrame\UI-SilverIcon.blp" />
+          <GameIcon file="interface/moneyframe/ui-silvericon.blp" />
         </span>
       ) : null}
 
       {copper ? (
         <span>
           {copper}&nbsp;
-          <GameIcon file="Interface\MoneyFrame\UI-CopperIcon.blp" />
+          <GameIcon file="interface/moneyframe/ui-coppericon.blp" />
         </span>
       ) : null}
     </span>

--- a/packages/spelunker-web/src/components/images/GameIcon/index.jsx
+++ b/packages/spelunker-web/src/components/images/GameIcon/index.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import { isPathBasename } from '../../../utils/pipeline';
 import GameImage from '../GameImage';
 
 import styles from './index.styl';
 
 const GameIcon = (props) => {
   let file = props.file;
-  if (!file.includes('\\')) {
-    file = `Interface\\Icons\\${file}`;
+  if (isPathBasename(file)) {
+    file = `interface/icons/${file}`;
   }
   if (!file.includes('.')) {
     file = `${file}.blp`;

--- a/packages/spelunker-web/src/components/images/GameIcon/index.jsx
+++ b/packages/spelunker-web/src/components/images/GameIcon/index.jsx
@@ -9,7 +9,7 @@ import styles from './index.styl';
 const GameIcon = (props) => {
   let file = props.file;
   if (isPathBasename(file)) {
-    file = `interface/icons/${file}`;
+    file = `Interface/Icons/${file}`;
   }
   if (!file.includes('.')) {
     file = `${file}.blp`;

--- a/packages/spelunker-web/src/components/images/GameImage/index.jsx
+++ b/packages/spelunker-web/src/components/images/GameImage/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import { toPipelinePath } from '../../../utils/pipeline';
+
 import styles from './index.styl';
 
 const GameImageBackground = (props) => {
@@ -33,7 +35,7 @@ const GameImageElement = (props) => {
 };
 
 const GameImage = (props) => {
-  const encoded = encodeURIComponent(props.file);
+  const encoded = encodeURI(toPipelinePath(props.file));
   const src = `${process.env.PIPELINE_URI}/${encoded}.png`;
 
   const Component = props.asBackground ? GameImageBackground : GameImageElement;

--- a/packages/spelunker-web/src/components/images/QuestgiverIcon.jsx
+++ b/packages/spelunker-web/src/components/images/QuestgiverIcon.jsx
@@ -10,7 +10,7 @@ const QuestgiverIcon = (props) => {
   return (
     <GameIcon
       {...props}
-      file="interface/gossipframe/availablequesticon.blp"
+      file="Interface/GossipFrame/AvailableQuestIcon.blp"
     />
   );
 };

--- a/packages/spelunker-web/src/components/images/QuestgiverIcon.jsx
+++ b/packages/spelunker-web/src/components/images/QuestgiverIcon.jsx
@@ -10,7 +10,7 @@ const QuestgiverIcon = (props) => {
   return (
     <GameIcon
       {...props}
-      file="Interface\GossipFrame\AvailableQuestIcon.blp"
+      file="interface/gossipframe/availablequesticon.blp"
     />
   );
 };

--- a/packages/spelunker-web/src/utils/pipeline.js
+++ b/packages/spelunker-web/src/utils/pipeline.js
@@ -1,0 +1,10 @@
+const PATH_SEPARATOR = /\\|\//;
+
+const isPathBasename = path => !PATH_SEPARATOR.test(path);
+
+const toPipelinePath = path => path.replace(/\\/g, '/').toLowerCase();
+
+export {
+  isPathBasename,
+  toPipelinePath,
+};


### PR DESCRIPTION
This PR modifies the pipeline server to support serving resources requested with forward-slashed paths `/` instead of the MPQ standard of backward-slashed paths `\`.

This PR also normalizes web client paths to always be forward-slashed `/` and lowercase (MPQ file lookups are case insensitive).

This hopefully makes it a bit easier to work with pipeline resources, and improves cache hit rates by preventing case mismatches from creating unique paths.