### PR TITLE
feat: render icons from BLPs directly

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -27,6 +27,7 @@ jobs:
       API_URI: 'http://localhost:3001/graphql'
       DEBUG: 'spelunker*'
       PIPELINE_URI: 'http://localhost:3001/pipeline'
+      DATA_URI: 'http://localhost:3001/data'
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2

--- a/packages/spelunker-web/package-lock.json
+++ b/packages/spelunker-web/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.4.17",
+        "@wowserhq/format": "^0.1.0",
         "classnames": "^2.3.1",
         "crypto-hash": "^2.0.0",
         "graphql": "^15.7.2",
@@ -2600,6 +2601,19 @@
         "eslint": "^7.1.0",
         "eslint-plugin-import": "^2.20.0"
       }
+    },
+    "node_modules/@wowserhq/format": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@wowserhq/format/-/format-0.1.0.tgz",
+      "integrity": "sha512-rlQAQ+H4gB07IxInldezoN4jUULyRLMFahUH7YAEZHs9BtyRI+KTGYzatYqkv7N1fx5wTqJVUbpFNR9/pkdKEw==",
+      "dependencies": {
+        "@wowserhq/io": "^1.2.2"
+      }
+    },
+    "node_modules/@wowserhq/io": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.2.2.tgz",
+      "integrity": "sha512-5M9KIm5Tv65xukPe45AnSqQdmwY0iM1YYZyb6kvLIHG/Y80cVOqOYJLnRN4/QGqHst03IIy6PUGKHIA7TdlBaw=="
     },
     "node_modules/@wry/trie": {
       "version": "0.3.1",
@@ -12954,6 +12968,19 @@
       "integrity": "sha512-MOVbCe4lowt6Ffno++f8uxGyA8NS4pV1UiqUShSzA+wbi8G0Vsf9JGM6C1pTXv9jGas9uV+ZzFHHWg8nZsXxQQ==",
       "dev": true,
       "requires": {}
+    },
+    "@wowserhq/format": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@wowserhq/format/-/format-0.1.0.tgz",
+      "integrity": "sha512-rlQAQ+H4gB07IxInldezoN4jUULyRLMFahUH7YAEZHs9BtyRI+KTGYzatYqkv7N1fx5wTqJVUbpFNR9/pkdKEw==",
+      "requires": {
+        "@wowserhq/io": "^1.2.2"
+      }
+    },
+    "@wowserhq/io": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.2.2.tgz",
+      "integrity": "sha512-5M9KIm5Tv65xukPe45AnSqQdmwY0iM1YYZyb6kvLIHG/Y80cVOqOYJLnRN4/QGqHst03IIy6PUGKHIA7TdlBaw=="
     },
     "@wry/trie": {
       "version": "0.3.1",

--- a/packages/spelunker-web/package.json
+++ b/packages/spelunker-web/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@apollo/client": "^3.4.17",
+    "@wowserhq/format": "^0.1.0",
     "classnames": "^2.3.1",
     "crypto-hash": "^2.0.0",
     "graphql": "^15.7.2",

--- a/packages/spelunker-web/src/components/entities/Class/Icon/index.styl
+++ b/packages/spelunker-web/src/components/entities/Class/Icon/index.styl
@@ -7,7 +7,7 @@
   max-height: 1.3em
 }
 
-.icon img {
+.icon canvas {
   transform-origin: top left
 }
 
@@ -25,7 +25,7 @@ $classes = {
 }
 
 for $class, $translate in $classes {
-  .{$class} img {
+  .{$class} canvas {
     transform: scale(4) $translate
   }
 }

--- a/packages/spelunker-web/src/components/entities/Race/Icon/index.styl
+++ b/packages/spelunker-web/src/components/entities/Race/Icon/index.styl
@@ -8,7 +8,7 @@
 }
 
 .icon {
-  img {
+  canvas {
     transform-origin: top left
   }
 }
@@ -46,7 +46,7 @@ $races = {
 }
 
 for $race, $translate in $races {
-  .{$race} img {
+  .{$race} canvas {
     transform: scale(8) $translate
   }
 }

--- a/packages/spelunker-web/src/components/images/GameImage/index.jsx
+++ b/packages/spelunker-web/src/components/images/GameImage/index.jsx
@@ -1,42 +1,72 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { Blp, BLP_IMAGE_FORMAT } from '@wowserhq/format';
 import classNames from 'classnames';
 
 import { toPipelinePath } from '../../../utils/pipeline';
 
 import styles from './index.styl';
 
+const loadBlp = async (canvas, src) => {
+  const blpResponse = await fetch(src);
+  const blpData = await blpResponse.arrayBuffer();
+  const blp = new Blp();
+  blp.load(new Uint8Array(blpData));
+
+  const image = blp.getImage(0, BLP_IMAGE_FORMAT.IMAGE_RGBA8888);
+  const imageData = new ImageData(new Uint8ClampedArray(image.data), image.width, image.height);
+
+  canvas.width = image.width;
+  canvas.height = image.height;
+
+  const context = canvas.getContext('2d');
+  context.putImageData(imageData, 0, 0);
+};
+
 const GameImageBackground = (props) => {
+  const canvasRef = useRef();
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      loadBlp(canvasRef.current, props.src);
+    }
+  }, [props.src]);
+
   const className = classNames(
     props.className,
     styles.image,
     styles.asBackground,
   );
+
   return (
     <span className={className}>
-      <img
-        // TODO: Set proper alt texts for all images
-        alt=""
-        src={props.src}
+      <canvas
+        ref={canvasRef}
       />
     </span>
   );
 };
 
 const GameImageElement = (props) => {
+  const canvasRef = useRef();
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      loadBlp(canvasRef.current, props.src);
+    }
+  }, [props.src]);
+
   const className = classNames(props.className, styles.image);
   return (
-    <img
+    <canvas
       // TODO: Set proper alt texts for all images
-      alt=""
+      ref={canvasRef}
       className={className}
-      src={props.src}
     />
   );
 };
 
 const GameImage = (props) => {
-  const encoded = encodeURI(toPipelinePath(props.file));
-  const src = `${process.env.PIPELINE_URI}/files/${encoded}.png`;
+  const src = `${process.env.DATA_URI}/${toPipelinePath(props.file)}`;
 
   const Component = props.asBackground ? GameImageBackground : GameImageElement;
   return <Component {...props} src={src} />;

--- a/packages/spelunker-web/src/components/images/GameImage/index.styl
+++ b/packages/spelunker-web/src/components/images/GameImage/index.styl
@@ -6,7 +6,7 @@
   display: inline-block
   overflow: hidden
 
-  img {
+  canvas {
     display: block
     max-width: 100%
     max-height: 100%

--- a/packages/spelunker-web/webpack.config.js
+++ b/packages/spelunker-web/webpack.config.js
@@ -11,6 +11,9 @@ module.exports = {
     publicPath: '/',
   },
   resolve: {
+    fallback: {
+      fs: false,
+    },
     extensions: ['.mjs', '.js', '.jsx'],
   },
   plugins: [

--- a/packages/spelunker-web/webpack.config.js
+++ b/packages/spelunker-web/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
       'API_URI',
       'DEBUG',
       'PIPELINE_URI',
+      'DATA_URI',
     ]),
   ],
   module: {


### PR DESCRIPTION
This PR introduces `Blp` from `@wowserhq/format` to permit `GameIcon`, `ClassIcon`, and `RaceIcon` to render icons without relying on PNGs converted from the the BLPs. This allows Spelunker to directly consume art assets hosted at `DATA_URI`.