### PR TITLE
feat(api): support filtering items by item class

### DIFF
--- a/packages/spelunker-api/src/lib/core/Query.mjs
+++ b/packages/spelunker-api/src/lib/core/Query.mjs
@@ -20,6 +20,13 @@ class Query {
     return this;
   }
 
+  filter(filters) {
+    if (filters) {
+      this.entity.filter(this, filters);
+    }
+    return this;
+  }
+
   slice() {
     notImplemented(this, 'slice');
   }

--- a/packages/spelunker-api/src/lib/entities/Item.mjs
+++ b/packages/spelunker-api/src/lib/entities/Item.mjs
@@ -27,6 +27,12 @@ class Item extends DatabaseEntity {
     query.where('name', 'LIKE', `%${searchQuery}%`);
   }
 
+  static filter(query, filters) {
+    if (filters?.itemClassIds?.length > 0) {
+      query.andWhere('class', 'IN', filters.itemClassIds);
+    }
+  }
+
   get id() {
     return this.data.entry;
   }

--- a/packages/spelunker-api/src/lib/graph/root.mjs
+++ b/packages/spelunker-api/src/lib/graph/root.mjs
@@ -29,7 +29,7 @@ export default {
   factions: ({ searchQuery }) => Faction.query.search(searchQuery),
   faction: ({ id }) => Faction.find(id),
 
-  items: ({ searchQuery }) => Item.query.search(searchQuery),
+  items: ({ searchQuery, ...filters }) => Item.query.search(searchQuery).filter(filters),
   item: ({ id }) => Item.find(id),
 
   itemSets: ({ searchQuery }) => ItemSet.query.search(searchQuery),

--- a/packages/spelunker-api/src/lib/graph/schema/QueryType.mjs
+++ b/packages/spelunker-api/src/lib/graph/schema/QueryType.mjs
@@ -1,5 +1,6 @@
 import {
   GraphQLInt,
+  GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
@@ -29,10 +30,11 @@ const finderFor = (type, idType = GraphQLInt) => ({
   },
 });
 
-const searchableCollectionFor = (type) => (
+const searchableCollectionFor = (type, filters = {}) => (
   CollectionType.definitionFor(type, {
     args: {
       searchQuery: { type: GraphQLString },
+      ...filters,
     },
   })
 );
@@ -55,7 +57,9 @@ export default new GraphQLObjectType({
     factions: searchableCollectionFor(FactionType),
     faction: finderFor(FactionType),
 
-    items: searchableCollectionFor(ItemType),
+    items: searchableCollectionFor(ItemType, {
+      itemClassIds: { type: new GraphQLList(GraphQLInt) },
+    }),
     item: finderFor(ItemType),
 
     itemSets: searchableCollectionFor(ItemSetType),


### PR DESCRIPTION
This PR introduces the ability to filter items by one or more item classes.

For example:
```
query ExampleQuery {
  items(searchQuery: "torment", itemClassIds: [2, 3]) {
    results {
      id, name, itemClass { id, name }
    }
  }
}
```
returns:
```
{
  "data": {
    "items": {
      "results": [
        {
          "id": 25806,
          "name": "Nethekurse's Rod of Torment",
          "itemClass": {
            "id": 2,
            "name": "Weapon"
          }
        },
        {
          "id": 39291,
          "name": "Torment of the Banished",
          "itemClass": {
            "id": 2,
            "name": "Weapon"
          }
        }
      ]
    }
  }
}
```

The PR introduces the notion of `filters` separate from `search`: `search` permits entering an entity name for a partial string match (as it already does today), while `filters` support type-and-field-specific equality checks. The collection level entities in the root of the schema would support both `searchQuery` and filters (assuming the entity type is worth filtering).