### PR TITLE
feat(web): add non-invasive privacy-friendly analytics to web app

### DIFF
--- a/packages/spelunker-web/src/index.html
+++ b/packages/spelunker-web/src/index.html
@@ -13,6 +13,8 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet" />
+
+    <script defer data-domain="spelunkerdb.com" src="https://plausible.io/js/script.js"></script>
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
This adds Plausible, a non-invasive privacy-friendly analytics to the web app. This is a paid service, does not monetize the data whatsoever and will hopefully provide us some insight into basic usage without having to sell our souls.

As Spelunker (and Wowser in general) are a bit techy in nature, there's a risk [it might get blocked by tech-savvy users](https://plausible.io/docs/proxy/introduction), but that's fine.

We could even decide to open these statistics up to the public: https://plausible.io/docs/visibility 🥳 